### PR TITLE
fix: change array_make to Array::make

### DIFF
--- a/examples/buffer/lib/buffer.mbt
+++ b/examples/buffer/lib/buffer.mbt
@@ -5,7 +5,7 @@ pub struct Buffer[T] {
 }
 
 pub func Buffer::new[T : Default](capacity : Int) -> Buffer[T] {
-  { cap: capacity, len: 0, data: array_make(capacity, T::default()) }
+  { cap: capacity, len: 0, data: Array::make(capacity, T::default()) }
 }
 
 pub func capacity[T](self : Buffer[T]) -> Int {
@@ -31,7 +31,7 @@ func expand_size[T : Default](self : Buffer[T]) {
     (self.cap + 1) * 2
   }
   self.cap = new_capacity
-  let new_data = array_make(new_capacity, T::default())
+  let new_data = Array::make(new_capacity, T::default())
   var index = 0
   while index < self.len {
     new_data[index] = self.data[index]
@@ -72,7 +72,7 @@ pub func clear[T : Default](self : Buffer[T]) {
 pub func reset[T : Default](self : Buffer[T], capacity : Int) {
   self.cap = capacity
   self.len = 0
-  self.data = array_make(capacity, T::default())
+  self.data = Array::make(capacity, T::default())
 }
 
 pub func println[T : Show](self : Buffer[T]) {

--- a/examples/path/lib/string.mbt
+++ b/examples/path/lib/string.mbt
@@ -1,6 +1,6 @@
 pub func split(s : String, sep : Char) -> (Array[String], Int) {
   var index = 0
-  var result : Array[String] = array_make(5, "")
+  var result : Array[String] = Array::make(5, "")
   var cur = 0
   let it = iter(s)
   while it.index != it.length {
@@ -10,7 +10,7 @@ pub func split(s : String, sep : Char) -> (Array[String], Int) {
       result.set(cur, sub)
       cur = cur + 1
       if cur >= result.length() {
-        var new_result = array_make(result.length() * 2, "")
+        var new_result = Array::make(result.length() * 2, "")
         var tmp_cur = 0
         while tmp_cur < result.length() {
           new_result.set(tmp_cur, result[tmp_cur])
@@ -123,7 +123,7 @@ pub func contains(s : String, sub : String) -> Bool {
 }
 
 func prefix_function(pattern : String) -> Array[Int] {
-  let result = array_make(pattern.length(), 0)
+  let result = Array::make(pattern.length(), 0)
   var n = pattern.length()
   var i = 1
   while i < n {
@@ -149,7 +149,7 @@ pub func char_at(s : String, pos : Int) -> Option[Char] {
 
 pub func to_char_array(s : String) -> Array[Char] {
   let l = s.length()
-  var array = array_make(l, ' ')
+  var array = Array::make(l, ' ')
   var index = 0
   while index < l {
     array[index] = s.get(index)

--- a/examples/string/lib/string.mbt
+++ b/examples/string/lib/string.mbt
@@ -1,6 +1,6 @@
 pub func split(s : String, sep : Char) -> (Array[String], Int) {
   var index = 0
-  var result : Array[String] = array_make(5, "")
+  var result : Array[String] = Array::make(5, "")
   var cur = 0
   let it = iter(s)
   while it.index != it.length {
@@ -10,7 +10,7 @@ pub func split(s : String, sep : Char) -> (Array[String], Int) {
       result.set(cur, sub)
       cur = cur + 1
       if cur >= result.length() {
-        var new_result = array_make(result.length() * 2, "")
+        var new_result = Array::make(result.length() * 2, "")
         var tmp_cur = 0
         while tmp_cur < result.length() {
           new_result.set(tmp_cur, result[tmp_cur])
@@ -123,7 +123,7 @@ pub func contains(s : String, sub : String) -> Bool {
 }
 
 func prefix_function(pattern : String) -> Array[Int] {
-  let result = array_make(pattern.length(), 0)
+  let result = Array::make(pattern.length(), 0)
   var n = pattern.length()
   var i = 1
   while i < n {
@@ -149,7 +149,7 @@ pub func char_at(s : String, pos : Int) -> Option[Char] {
 
 pub func to_char_array(s : String) -> Array[Char] {
   let l = s.length()
-  var array = array_make(l, ' ')
+  var array = Array::make(l, ' ')
   var index = 0
   while index < l {
     array[index] = s.get(index)


### PR DESCRIPTION
examples/buffer, examples/path, examples/string still build failed

output:
moonbit-docs/examples/buffer/main/main.mbt:16:7-16:12 Error (warning 015): The mutability of 'index' is never used

moonbit-docs/examples/path/lib/string.mbt:13:13-13:23 Error (warning 015): The mutability of 'new_result' is never used.
moonbit-docs/examples/path/lib/string.mbt:127:7-127:8 Error (warning 015): The mutability of 'n' is never used.
moonbit-docs/examples/path/lib/string.mbt:152:7-152:12 Error (warning 015): The mutability of 'array' is never used.

moonbit-docs/examples/string/lib/string.mbt:13:13-13:23 Error (warning 015): The mutability of 'new_result' is never used.
moonbit-docs/examples/string/lib/string.mbt:127:7-127:8 Error (warning 015): The mutability of 'n' is never used.
moonbit-docs/examples/string/lib/string.mbt:152:7-152:12 Error (warning 015): The mutability of 'array' is never used.

