### PR TITLE
chore: fix moon new usage

### DIFF
--- a/build-system-tutorial.md
+++ b/build-system-tutorial.md
@@ -42,7 +42,7 @@ To create a new module, use the `moon new` command in your terminal:
 moon new
 ```
 
-This command will launch a new module wizard. Following all default options will a new module named `hello` in the `my-project` directory.
+This command will launch a new module wizard. Following all default options will create a new module named `hello` in the `my-project` directory.
 
 ## Understanding the Module Directory Structure
 

--- a/build-system-tutorial.md
+++ b/build-system-tutorial.md
@@ -36,20 +36,20 @@ Once you have these prerequisites fulfilled, let's start building a new module i
 
 ## Creating a New Module
 
-To create a new module, use the `moon new hello` command in your terminal:
+To create a new module, use the `moon new` command in your terminal:
 
 ```bash
-moon new hello
+moon new
 ```
 
-This command will create a new module named `hello`.
+This command will launch a new module wizard. Following all default options will a new module named `hello` in the `my-project` directory.
 
 ## Understanding the Module Directory Structure
 
 After creating the new module, your directory structure should resemble the following:
 
 ```bash
-.
+my-project
 ├── lib
 │   ├── hello.mbt
 │   └── moon.pkg.json

--- a/zh-docs/build-system-tutorial.md
+++ b/zh-docs/build-system-tutorial.md
@@ -38,20 +38,20 @@ Moon 是 MoonBit 语言的构建系统，目前基于[n2](https://github.com/evm
 
 ## 创建一个新模块
 
-要创建一个新模块，在终端中输入`moon new hello`命令：
+要创建一个新模块，在终端中输入 `moon new` 命令：
 
 ```bash
-$ moon new hello
+$ moon new
 ```
 
-该命令将创建一个名为`hello`的新模块。
+您将看到模块创建向导，使用默认值即可在 `my-project` 目录下创建一个名为 `hello` 的新模块。
 
 ## 理解模块目录结构
 
 创建新模块后，目录结构应如下所示：
 
 ```bash
-.
+my-project
 ├── lib
 │   ├── hello.mbt
 │   └── moon.pkg.json


### PR DESCRIPTION
当前文档中对 `moon new` 命令的使用方式描述不正确（已不能使用 `hello` 作为参数），本 PR 修复文档中相关的表述