### PR TITLE
修改zh-docs中的错误

### DIFF
--- a/zh-docs/README.md
+++ b/zh-docs/README.md
@@ -522,14 +522,14 @@ enum List[T] {
   Cons(T, List[T])
 }
 
-fn map[S, T](self: List[S], f: (S) => T) -> List[T] {
+fn map[S, T](self: List[S], f: (S) -> T) -> List[T] {
   match self {
     Nil => Nil
     Cons(x, xs) => Cons(f(x), map(xs, f))
   }
 }
 
-fn reduce[S, T](self: List[S], op: (T, S) => T, init: T) -> T {
+fn reduce[S, T](self: List[S], op: (T, S) -> T, init: T) -> T {
   match self {
     Nil => init
     Cons(x, xs) => reduce(xs, op, op(init, x))


### PR DESCRIPTION
函数类型定义
```
f: (S) -> T
```
误写成
```
f: (S) => T
```