### PR TITLE
docs(Array): rename array to numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,17 +348,17 @@ fn init {
 An array is a finite sequence of values constructed using square brackets `[]`, with elements separated by commas `,`. For example:
 
 ```go
-let array = [1, 2, 3, 4]
+let numbers = [1, 2, 3, 4]
 ```
 
-You can use `array[x]` to refer to the xth element. The index starts from zero.
+You can use `numbers[x]` to refer to the xth element. The index starts from zero.
 
 ```go live
 fn init {
-  let array = [1, 2, 3, 4]
-  let a = array[2]
-  array[3] = 5
-  let b = a + array[3]
+  let numbers = [1, 2, 3, 4]
+  let a = numbers[2]
+  numbers[3] = 5
+  let b = a + numbers[3]
   print(b) // prints 8
 }
 ```

--- a/zh-docs/README.md
+++ b/zh-docs/README.md
@@ -351,17 +351,17 @@ fn init {
 数组是由方括号 `[]` 构造的有限值序列，其中元素由逗号 `,` 分隔。例如：
 
 ```rust
-let array = [1, 2, 3, 4]
+let numbers = [1, 2, 3, 4]
 ```
 
-可以用 `array[x]` 来引用第 `x` 个元素。索引从零开始。
+可以用 `numbers[x]` 来引用第 `x` 个元素。索引从零开始。
 
 ```rust live
 fn init {
-  let array = [1, 2, 3, 4]
-  let a = array[2]
-  array[3] = 5
-  let b = a + array[3]
+  let numbers = [1, 2, 3, 4]
+  let a = numbers[2]
+  numbers[3] = 5
+  let b = a + numbers[3]
   print(b)  // 打印 8
 }
 ```


### PR DESCRIPTION
The color of `array` make me feel it's a keyword.

Before:
![image](https://github.com/moonbitlang/moonbit-docs/assets/111219127/4ec5a74e-684a-4858-90d5-be55f342e33b)

After:
![image](https://github.com/moonbitlang/moonbit-docs/assets/111219127/a9ec7415-d571-4d04-8d12-624e524ad1f9)
