### PR TITLE
Add return type in assert_eq

### DIFF
--- a/build-system-tutorial.md
+++ b/build-system-tutorial.md
@@ -277,7 +277,7 @@ Let's add some tests to verify our fib implementation. Add the following content
 
 `lib/fib/a.mbt`
 ```rust
-fn assert_eq[T: Show + Eq](lhs: T, rhs: T) {
+fn assert_eq[T: Show + Eq](lhs: T, rhs: T) -> Unit {
   if lhs != rhs {
     abort("assert_eq failed.\n    lhs: \(lhs)\n    rhs: \(rhs)")
   }

--- a/zh-docs/build-system-tutorial.md
+++ b/zh-docs/build-system-tutorial.md
@@ -273,7 +273,7 @@ Hello, world!
 `lib/fib/a.mbt`
 
 ```rust
-fn assert_eq[T: Show + Eq](lhs: T, rhs: T) {
+fn assert_eq[T: Show + Eq](lhs: T, rhs: T) -> Unit {
   if lhs != rhs {
     abort("assert_eq failed.\n    lhs: \(lhs)\n    rhs: \(rhs)")
   }


### PR DESCRIPTION
Hi all,

The funtion `assert_eq` in `build-system-tutorial.md` can't be compiled successfully because the return value of the top funtion requires explicit type annotation [1][2]. This patch fixes it.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

[1] https://www.moonbitlang.com/weekly-updates#3-now-a-top-level-function-without-a-marked-return-value-is-an-error
[2] https://www.moonbitlang.com/docs/syntax#top-level-functions