### PR TITLE
Remove a wrong comma in enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,7 +728,7 @@ MoonBit supports methods in a different way from traditional object-oriented lan
 
 ```rust
 enum MyList[X] {
-  Nil,
+  Nil
   Cons(X, MyList[X])
 }
 

--- a/zh-docs/README.md
+++ b/zh-docs/README.md
@@ -736,7 +736,7 @@ MoonBit 支持与传统面向对象语言不同的方法（method）。
 
 ```rust
 enum MyList[X] {
-  Nil,
+  Nil
   Cons(X, MyList[X])
 }
 


### PR DESCRIPTION
Hi all,

This patch removes a wrong comma in enum. The previous code snippet can't be compiled.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong