### PR TITLE
Add an example about operator overloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -805,6 +805,38 @@ fn init {
 }
 ```
 
+Another example about `op_get` and `op_set`:
+
+```rust
+struct Coord {
+  mut x: Int
+  mut y: Int
+} derive(Debug)
+
+fn op_get(self: Coord, key: String) -> Int {
+  match key {
+    "x" => self.x
+    "y" => self.y
+  }
+}
+
+fn op_set(self: Coord, key: String, val: Int) -> Unit {
+    match key {
+    "x" => self.x = val
+    "y" => self.y = val
+  }
+}
+
+fn init {
+  let c = { x: 1, y: 2 }
+  debug(c)
+  debug(c["y"])
+  c["x"] = 23
+  debug(c)
+  debug(c["x"])
+}
+```
+
 Currently, the following operators can be overloaded:
 
 | operator name        | method name |

--- a/zh-docs/README.md
+++ b/zh-docs/README.md
@@ -798,6 +798,38 @@ fn init {
 }
 ```
 
+另一个例子（关于`op_get`和`op_set`）:
+
+```rust
+struct Coord {
+  mut x: Int
+  mut y: Int
+} derive(Debug)
+
+fn op_get(self: Coord, key: String) -> Int {
+  match key {
+    "x" => self.x
+    "y" => self.y
+  }
+}
+
+fn op_set(self: Coord, key: String, val: Int) -> Unit {
+    match key {
+    "x" => self.x = val
+    "y" => self.y = val
+  }
+}
+
+fn init {
+  let c = { x: 1, y: 2 }
+  debug(c)
+  debug(c["y"])
+  c["x"] = 23
+  debug(c)
+  debug(c["x"])
+}
+```
+
 目前，以下运算符可以被重载：
 
 | 运算符名称           | 方法名      |


### PR DESCRIPTION
Hi all,

When I read `_[_](get item)` first time, I misunderstood it as one or two underline `_`. I searched `op_get` and `op_set` in the core library, then I knew what I misunderstood. So I think it is good to provide an example about `op_get` and `op_set`.

Thanks for your review.

Best Regards,
-- Guoxiong