### PR TITLE
Add more comments in the example of pipe operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -824,10 +824,12 @@ MoonBit provides a convenient pipe operator `|>`, which can be used to chain reg
 ```rust
 fn init {
   x |> f // equivalent to f(x)
-  x |> f(y) // equivalent to f(x, y)
-  initial
-  |> function1
-  |> function2(other_arguments)
+  x |> g(y) // equivalent to f(x, y)
+
+  // Chain calls at multiple lines
+  arg_val
+  |> f1 // equivalent to f1(arg_val)
+  |> f2(other_args) // equivalent to f2(f1(arg_val), other_args)
 }
 ```
 

--- a/zh-docs/README.md
+++ b/zh-docs/README.md
@@ -819,9 +819,11 @@ MoonBit 提供了便利的管道运算符 `|>`，可以用于链式调用普通�
 fn init {
   x |> f     // 等价于 f(x)
   x |> f(y)  // 等价于 f(x, y)
-  initial
-  |> function1
-  |> function2(other_arguments)
+
+  // 分布在多行的链式调用
+  arg_val
+  |> f1 // 等价于 f1(arg_val)
+  |> f2(other_args) // 等价于 f2(f1(arg_val), other_args)
 }
 ```
 


### PR DESCRIPTION
Hi all,

The example of `pipe operator` (shown below) seems strange to me, especailly the word `initial`. I misunderstood it as a comment which misses `//`. So it is good to add more comments and adjust the names of the arguments.

```rust
fn init {
  x |> f // equivalent to f(x)
  x |> f(y) // equivalent to f(x, y)
  initial   // <-- strange
  |> function1
  |> function2(other_arguments)
}
```

Thanks for taking the time to review.

Best Regards,
-- Guoxiong