### PR TITLE
Add return types in the methods of the traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -925,7 +925,7 @@ trait Default {
 
 trait Debug {
   // write debug information of [self] to a buffer
-  debug_write(Self, Buffer)
+  debug_write(Self, Buffer) -> Unit
 }
 ```
 
@@ -937,7 +937,7 @@ However, it is often useful to extend the functionality of an existing type. So 
 
 ```rust
 trait ToMyBinaryProtocol {
-  to_my_binary_protocol(Self, Buffer)
+  to_my_binary_protocol(Self, Buffer) -> Unit
 }
 
 fn ToMyBinaryProtocol::to_my_binary_protocol(x: Int, b: Buffer) -> Unit { ... }
@@ -951,7 +951,7 @@ To invoke an extension method directly, use the `Trait::method` syntax.
 
 ```rust
 trait MyTrait {
-  f(Self)
+  f(Self) -> Unit
 }
 
 fn MyTrait::f(self: Int) -> Unit {

--- a/zh-docs/README.md
+++ b/zh-docs/README.md
@@ -930,7 +930,7 @@ trait Default {
 
 trait Debug {
   // 将 [self] 的调试信息写入到一个 buffer 里
-  debug_write(Self, Buffer)
+  debug_write(Self, Buffer) -> Unit
 }
 ```
 
@@ -947,7 +947,7 @@ trait Debug {
 
 ```rust
 trait ToMyBinaryProtocol {
-  to_my_binary_protocol(Self, Buffer)
+  to_my_binary_protocol(Self, Buffer) -> Unit
 }
 
 fn ToMyBinaryProtocol::to_my_binary_protocol(x: Int, b: Buffer) -> Unit { ... }
@@ -966,7 +966,7 @@ fn ToMyBinaryProtocol::to_my_binary_protocol(x: String, b: Buffer) -> Unit { ...
 
 ```rust
 trait MyTrait {
-  f(Self)
+  f(Self) -> Unit
 }
 
 fn MyTrait::f(self: Int) -> Unit {


### PR DESCRIPTION
Hi all,

When the return types are missed in the methods of the traits, they can't be compiled successfully now. So it is good to add them.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong