### PR TITLE
fix: wrong return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ The default expression will be evaluated everytime it is used. And the side effe
 ```rust
 fn incr(~counter : Ref[Int] = { val: 0 }) -> Int {
   counter.val = counter.val + 1
-  counter
+  counter.val
 }
 
 fn init {


### PR DESCRIPTION
Just found a tiny mistake.

The code in the original document doesn't work for me.

It throws following error
```
$ moon run main
failed: moonc build-package /home/d2verb/workspace/misc/study/moonbit/sample/main/main.mbt -o /home/d2verb/workspace/misc/study/moonbit/sample/target/wasm/release/build/main/main.core -pkg d2verb/sample/main -is-main -std-path /home/d2verb/.moon/lib/core/target/bundle -i /home/d2verb/workspace/misc/study/moonbit/sample/target/wasm/release/build/lib/lib.mi:lib -pkg-sources d2verb/sample/main:/home/d2verb/workspace/misc/study/moonbit/sample/main
/home/d2verb/workspace/misc/study/moonbit/sample/main/main.mbt:3:3-3:10 Expr Type Mismatch
        has type : Ref[Int]
        wanted   : Int
```

The code I wrote
```rust
// main.mbt
fn incr(~counter : Ref[Int] = { val: 0 }) -> Int {
  counter.val = counter.val + 1
  counter
}

fn main {
  println(incr()) // 1
  println(incr()) // still 1, since a new reference is created everytime default expression is used
  let counter : Ref[Int] = { val: 0 }
  println(incr(~counter)) // 1
  println(incr(~counter)) // 2, since the same counter is used
}
```

moonbit version
```
$ moon version
moon 0.1.0 (9b4910e 2024-04-22)
```
