### PR TITLE
Fix minor typo and add more live codeblocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Labelled function can be supplied in any order. The evaluation order of argument
 ### Optional arguments
 A labelled argument can be made optional by supplying a default expression with the syntax `~label : Type = default_expr`. If this argument is not supplied at call site, the default expression will be used:
 
-```rust
+```rust live
 fn optional(~opt : Int = 42) -> Int {
   opt
 }
@@ -184,7 +184,7 @@ fn init {
 
 The default expression will be evaluated everytime it is used. And the side effect in the default expression, if any, will also be triggered. For example:
 
-```rust
+```rust live
 fn incr(~counter : Ref[Int] = { val: 0 }) -> Ref[Int] {
   counter.val = counter.val + 1
   counter
@@ -201,7 +201,7 @@ fn init {
 
 If you want to share the result of default expression between different function calls, you can lift the default expression to a toplevel `let` declaration:
 
-```rust
+```rust live
 let default_counter : Ref[Int] = { val: 0 }
 
 fn incr(~counter : Ref[Int] = default_counter) -> Int {
@@ -290,7 +290,7 @@ Functional loop is a powerful feature in MoonBit that enables you to write loops
 
 A functional loop consumes arguments and returns a value. It is defined using the `loop` keyword, followed by its arguments and the loop body. The loop body is a sequence of clauses, each of which consists of a pattern and an expression. The clause whose pattern matches the input will be executed, and the loop will return the value of the expression. If no pattern matches, the loop will panic. Use the `continue` keyword with arguments to start the next iteration of the loop. Use the `break` keyword with arguments to return a value from the loop. The `break` keyword can be omitted if the value is the last expression in the loop body.
 
-```rust
+```rust live
 fn sum(xs: List[Int]) -> Int {
   loop xs, 0 {
     Nil, acc => break acc // break can be omitted
@@ -352,11 +352,11 @@ let e = not(a)
 
 MoonBit have integer type and floating point type:
 
-|type|description|
-|-|-|
-|`Int`|32-bit signed integer|
-|`Int64`|64-bit signed integer|
-|`Double`|64-bit floating point, defined by IEEE754|
+| type     | description                               |
+| -------- | ----------------------------------------- |
+| `Int`    | 32-bit signed integer                     |
+| `Int64`  | 64-bit signed integer                     |
+| `Double` | 64-bit floating point, defined by IEEE754 |
 
 MoonBit also supports numeric literals, including decimal, binary, octal, and hexadecimal numbers.
 
@@ -405,21 +405,21 @@ println(a[1]) // output: r
 ```
 
 ```rust
-let b = 
+let b =
   #| Hello
   #| MoonBit
   #|
 ```
 
-In double quotes string, a backslash followed by certain special characters forms an escape sequence: 
+In double quotes string, a backslash followed by certain special characters forms an escape sequence:
 
-|escape sequences|description|
-|-|-|
-|`\n`,`\r`,`\t`,`\b`|New line, Carriage return, Horizontal tab, Backspace|
-|`\\`|Backslash|
-|`\x41`|Hexadecimal escape sequence|
-|`\o102`|Octal escape sequence|
-|`\u5154`,`\u{1F600}`|Unicode escape sequence|
+| escape sequences     | description                                          |
+| -------------------- | ---------------------------------------------------- |
+| `\n`,`\r`,`\t`,`\b`  | New line, Carriage return, Horizontal tab, Backspace |
+| `\\`                 | Backslash                                            |
+| `\x41`               | Hexadecimal escape sequence                          |
+| `\o102`              | Octal escape sequence                                |
+| `\u5154`,`\u{1F600}` | Unicode escape sequence                              |
 
 
 MoonBit supports string interpolation. It enables you to substitute variables within interpolated strings. This feature simplifies the process of constructing dynamic strings by directly embedding variable values into the text.
@@ -447,7 +447,7 @@ let c = '🐰'
 
 A byte literal in MoonBit is either a single ASCII character or a single escape enclosed in single quotes `'`, and preceded by the character `b`. Byte literals are of type `Byte`. For example:
 
-```rust
+```rust live
 fn init {
   let b1 : Byte = b'a'
   println(b1.to_int())
@@ -553,7 +553,7 @@ fn init {
 
 If you already have some variable like `name` and `email`, it's redundant to repeat those names when constructing a struct:
 
-```go
+```go live
 fn init{
   let name = "john"
   let email = "john@doe.com"
@@ -563,7 +563,7 @@ fn init{
 
 You can use shorthand instead, it behaves exactly the same.
 
-```go
+```go live
 fn init{
   let name = "john"
   let email = "john@doe.com"
@@ -575,7 +575,7 @@ fn init{
 
 It's useful to create a new struct based on an existing one, but with some fields updated.
 
-```rust
+```rust live
 struct User {
   id: Int
   name: String
@@ -687,7 +687,7 @@ fn is_singleton(l: List) -> Bool {
 
 #### Constructor with labelled arguments
 Enum constructors can have labelled argument:
-```rust
+```rust live
 enum E {
   // `x` and `y` are alabelled argument
   C(~x : Int, ~y : Int)
@@ -713,10 +713,10 @@ fn init {
 ```
 
 It is also possible to access labelled arguments of constructors like accessing struct fields in pattern matching:
-```rust
+```rust live
 enum Object {
   Point(~x : Double, ~y : Double)
-  Circle(~x : Double, ~y : Double, ~raidus : Double)
+  Circle(~x : Double, ~y : Double, ~radius : Double)
 }
 
 fn distance_with(self : Object, other : Object) -> Double {
@@ -742,7 +742,7 @@ fn init {
 
 #### Constructor with mutable fields
 It is also possible to define mutable fields for constructor. This is especially useful for defining imperative data structures:
-```rust
+```rust live
 // A mutable binary search tree with parent pointer
 enum Tree[X] {
   Nil
@@ -1010,7 +1010,7 @@ fn init {
 
 Unlike regular functions, methods support overloading: different types can define methods of the same name. If there are multiple methods of the same name (but for different types) in scope, one can still call them by explicitly adding a `TypeName::` prefix:
 
-```rust
+```rust live
 struct T1 { x1: Int }
 fn T1::default() -> { { x1: 0 } }
 
@@ -1044,7 +1044,7 @@ fn init {
 
 MoonBit supports operator overloading of builtin operators via methods. The method name corresponding to a operator `<op>` is `op_<op>`. For example:
 
-```rust
+```rust live
 struct T {
   x:Int
 } derive(Debug)
@@ -1062,7 +1062,7 @@ fn init {
 
 Another example about `op_get` and `op_set`:
 
-```rust
+```rust live
 struct Coord {
   mut x: Int
   mut y: Int
@@ -1181,7 +1181,7 @@ fn op_mul(self: Point, other: Point) -> Point {
 
 Methods of a trait can be called directly via `Trait::method`. MoonBit will infer the type of `Self` and check if `Self` indeed implements `Trait`, for example:
 
-```rust
+```rust live
 fn init {
   println(Show::to_string(42))
   debug(Compare::compare(1.0, 2.5))
@@ -1238,7 +1238,7 @@ When searching for the implementation of a trait, extension methods have a highe
 
 To invoke an extension method directly, use the `Trait::method` syntax.
 
-```rust
+```rust live
 trait MyTrait {
   f(Self) -> Unit
 }
@@ -1257,7 +1257,7 @@ fn init {
 
 MoonBit can automatically derive implementations for some builtin traits:
 
-```rust
+```rust live
 struct T {
   x: Int
   y: Int
@@ -1281,7 +1281,7 @@ into a runtime object via `t as I`.
 Trait object erases the concrete type of a value,
 so objects created from different concrete types can be put in the same data structure and handled uniformly:
 
-```rust
+```rust live
 trait Animal {
   speak(Self)
 }

--- a/build-system-tutorial.md
+++ b/build-system-tutorial.md
@@ -133,7 +133,7 @@ The `lib` package contains `hello.mbt` and `hello_test.mbt` files:
   ```rust
   test "hello" {
     if hello() != "Hello, world!" {
-      abort("")
+      return Err("hello() != \"Hello, world!\"")
     }
   }
   ```

--- a/build-system-tutorial.md
+++ b/build-system-tutorial.md
@@ -327,11 +327,12 @@ Finally, use the `moon test` command, which scans the entire project, identifies
 
 ```bash
 $ moon test
-test lib/fib ... ok
-test lib ... ok
-fib(10) = 55, fib(11) = 89
-Hello, world!
-test main ... ok
+Total tests: 3, passed: 3, failed: 0.
+$ moon test -v
+test username/hello/lib/hello_test.mbt::hello ok
+test username/hello/lib/fib/a.mbt::0 ok
+test username/hello/lib/fib/fib_test.mbt::0 ok
+Total tests: 3, passed: 3, failed: 0.
 ```
 
 Note that `main/main.mbt:init` is also executed here, and we will improve the issue of testing with package initialization functions in the future.

--- a/build-system-tutorial.md
+++ b/build-system-tutorial.md
@@ -106,7 +106,13 @@ Here's a brief explanation of the directory structure:
 
   ```json
   {
-    "name": "hello"
+    "name": "username/hello",
+    "version": "0.1.0",
+    "readme": "README.md",
+    "repository": "",
+    "license": "Apache-2.0",
+    "keywords": [],
+    "description": ""
   }
   ```
 
@@ -258,7 +264,7 @@ fn main {
   let a = @my_awesome_fibonacci.fib(10)
   let b = @my_awesome_fibonacci.fib2(11)
   println("fib(10) = \(a), fib(11) = \(b)")
-  
+
   println(@lib.hello())
 }
 ```

--- a/build-system-tutorial.md
+++ b/build-system-tutorial.md
@@ -160,6 +160,12 @@ $ moon run main
 Hello, world!
 ```
 
+You can test using the `moon test` command:
+
+```bash
+$ moon test
+Total tests: 1, passed: 1, failed: 0.
+```
 
 ## Package Importing
 

--- a/zh-docs/README.md
+++ b/zh-docs/README.md
@@ -175,7 +175,7 @@ fn init {
 ### 可选的参数
 可选的参数是带有默认值的带标签参数。声明可选的参数的语法是 `~label : Type = default_expr`。调用函数时，如果没有提供这个参数，就会使用默认值作为参数：
 
-```rust
+```rust live
 fn optional(~opt : Int = 42) -> Int {
   opt
 }
@@ -188,7 +188,7 @@ fn init {
 
 每次使用默认参数调用一个函数时，都会重新求值默认值的表达式，也会被重新触发其中的副作用。例如：
 
-```rust
+```rust live
 fn incr(~counter : Ref[Int] = { val: 0 }) -> Ref[Int] {
   counter.val = counter.val + 1
   counter
@@ -205,7 +205,7 @@ fn init {
 
 如果想要在多次不同的函数调用之间共享默认值，可以提前用 `let` 计算并保存默认值：
 
-```rust
+```rust live
 let default_counter : Ref[Int] = { val: 0 }
 
 fn incr(~counter : Ref[Int] = default_counter) -> Int {
@@ -294,7 +294,7 @@ if x == y {
 可以使用 `continue` 关键字和参数开始下一次循环迭代，使用 `break` 关键字和参数来从循环中返回一个值。
 如果值是循环体中的最后一个表达式，则可以省略 `break` 关键字。
 
-```rust
+```rust live
 fn sum(xs: List[Int]) -> Int {
   loop xs, 0 {
     Nil, acc => break acc // break 可以省略
@@ -357,11 +357,11 @@ let e = not(a)
 
 MoonBit 支持整型和浮点类型：
 
-|类型|描述|
-|-|-|
-|`Int`|32位有符号整数|
-|`Int64`|64位有符号整数|
-|`Double`|64位浮点数，由IEEE754定义|
+| 类型     | 描述                      |
+| -------- | ------------------------- |
+| `Int`    | 32位有符号整数            |
+| `Int64`  | 64位有符号整数            |
+| `Double` | 64位浮点数，由IEEE754定义 |
 
 MoonBit 支持的数字字面量，包括十进制、二进制、八进制和十六进制。
 
@@ -403,7 +403,7 @@ println(a[1]) // output: r
 ```
 
 ```rust
-let b = 
+let b =
   #| Hello
   #| MoonBit
   #|
@@ -411,13 +411,13 @@ let b =
 
 在双引号包围的字符串之间支持使用`\`表示特殊字符转义：
 
-|转义序列|解释|
-|-|-|
-|`\n`,`\r`,`\t`,`\b`|换行、回车、水平制表符、退格|
-|`\\`|反斜杠|
-|`\x41`|16进制转义序列|
-|`\o102`|8进制转义序列|
-|`\u5154`,`\u{1F600}`|Unicode字符转义序列|
+| 转义序列             | 解释                         |
+| -------------------- | ---------------------------- |
+| `\n`,`\r`,`\t`,`\b`  | 换行、回车、水平制表符、退格 |
+| `\\`                 | 反斜杠                       |
+| `\x41`               | 16进制转义序列               |
+| `\o102`              | 8进制转义序列                |
+| `\u5154`,`\u{1F600}` | Unicode字符转义序列          |
 
 
 MoonBit支持字符串插值，它可以把字符串中内插的变量替换为变量具体的值。
@@ -446,7 +446,7 @@ let c = '🐰'
 
 在MoonBit中，字节字面量可以是一个ASCII字符或一个转义序列，它们被单引号`'`包围，并且前面有字符`b`。字节字面量的类型是Byte。例如：
 
-```rust
+```rust live
 fn init {
   let b1 : Byte = b'a'
   println(b1.to_int())
@@ -572,7 +572,7 @@ fn init{
 如果想要基于现有的结构体来创建新的结构体，只需修改现有结构体的一部分字段，其他字段的值保持不变，
 可以使用结构体更新语法：
 
-```rust
+```rust live
 struct User {
   id: Int
   name: String
@@ -682,7 +682,7 @@ fn is_singleton(l: List) -> Bool {
 
 #### 带标签的构造器参数
 枚举构造器可以有带标签的参数：
-```rust
+```rust live
 enum E {
   // `x` 和 `y` 是带标签的参数
   C(~x : Int, ~y : Int)
@@ -709,10 +709,10 @@ fn init {
 
 在模式匹配中，还可以像访问结构体的字段一样直访问取构造器的带标签参数：
 
-```rust
+```rust live
 enum Object {
   Point(~x : Double, ~y : Double)
-  Circle(~x : Double, ~y : Double, ~raidus : Double)
+  Circle(~x : Double, ~y : Double, ~radius : Double)
 }
 
 fn distance_with(self : Object, other : Object) -> Double {
@@ -738,7 +738,7 @@ fn init {
 
 ### 构造器的可变字段
 MoonBit 支持给构造器声明可变的字段。这对实现可变数据结构非常有用：
-```rust
+```rust live
 // 一个带父节点指针的可变二叉搜索树的类型
 enum Tree[X] {
   Nil
@@ -1017,7 +1017,7 @@ fn init {
 但和普通函数不同，方法支持重载。不同的类型可以有同名的方法。
 如果当前作用域内有多个同名方法，依然可以通过加上 `TypeName::` 的前缀来显式地调用一个方法：
 
-```rust
+```rust live
 struct T1 { x1: Int }
 fn T1::default() -> { { x1: 0 } }
 
@@ -1053,7 +1053,7 @@ fn init {
 
 另一个例子（关于`op_get`和`op_set`）:
 
-```rust
+```rust live
 struct Coord {
   mut x: Int
   mut y: Int
@@ -1085,16 +1085,16 @@ fn init {
 
 目前，以下运算符可以被重载：
 
-| 运算符名称           | 方法名      |
-| -------------------- | ----------- |
-| `+`                  | `op_add`    |
-| `-`                  | `op_sub`    |
-| `*`                  | `op_mul`    |
-| `/`                  | `op_div`    |
-| `%`                  | `op_mod`    |
-| `-`（一元运算符）    | `op_neg`    |
-| `_[_]`（获取项）     | `op_get`    |
-| `_[_] = _`（设置项） | `op_set`    |
+| 运算符名称           | 方法名   |
+| -------------------- | -------- |
+| `+`                  | `op_add` |
+| `-`                  | `op_sub` |
+| `*`                  | `op_mul` |
+| `/`                  | `op_div` |
+| `%`                  | `op_mod` |
+| `-`（一元运算符）    | `op_neg` |
+| `_[_]`（获取项）     | `op_get` |
+| `_[_] = _`（设置项） | `op_set` |
 
 ## 管道运算符
 
@@ -1184,7 +1184,7 @@ fn op_mul(self: Point, other: Point) -> Point {
 接口中的方法可以用 `Trait::method` 的语法来直接调用。MoonBit 会推导 `Self` 的具体类型，
 并检查 `Self` 是否实现了 `Trait`：
 
-```rust
+```rust live
 fn init {
   println(Show::to_string(42))
   debug(Compare::compare(1.0, 2.5))
@@ -1251,7 +1251,7 @@ fn ToMyBinaryProtocol::to_my_binary_protocol(x: String, b: Buffer) -> Unit { ...
 
 如果需要直接调用一个拓展方法，可以使用 `Trait::method` 语法。例如：
 
-```rust
+```rust live
 trait MyTrait {
   f(Self) -> Unit
 }
@@ -1269,7 +1269,7 @@ fn init {
 
 Moonbit 可以自动生成一些内建接口的实现:
 
-```rust
+```rust live
 struct T {
   x: Int
   y: Int
@@ -1294,7 +1294,7 @@ MoonBit 通过接口对象的形式来支持运行时多态。
 接口对象擦除了值的具体类型，所以从不同的具体类型所创建的接口对象，
 可以被封装在同一个数据结构里，统一进行处理：
 
-```rust
+```rust live
 trait Animal {
   speak(Self)
 }

--- a/zh-docs/build-system-tutorial.md
+++ b/zh-docs/build-system-tutorial.md
@@ -325,11 +325,12 @@ test {
 
 ```bash
 $ moon test
-test lib/fib ... ok
-test lib ... ok
-fib(10) = 55, fib(11) = 89
-Hello, world!
-test main ... ok
+Total tests: 3, passed: 3, failed: 0.
+$ moon test -v
+test username/hello/lib/hello_test.mbt::hello ok
+test username/hello/lib/fib/a.mbt::0 ok
+test username/hello/lib/fib/fib_test.mbt::0 ok
+Total tests: 3, passed: 3, failed: 0.
 ```
 
 注意这里也执行了 `main/main.mbt:init`，后续我们将会改善测试与包初始化函数的问题。

--- a/zh-docs/build-system-tutorial.md
+++ b/zh-docs/build-system-tutorial.md
@@ -129,7 +129,7 @@ my-project
   ```rust
   test "hello" {
     if hello() != "Hello, world!" {
-      abort("")
+      return Err("hello() != \"Hello, world!\"")
     }
   }
   ```

--- a/zh-docs/build-system-tutorial.md
+++ b/zh-docs/build-system-tutorial.md
@@ -156,6 +156,13 @@ $ moon run main
 Hello, world!
 ```
 
+您可以使用 `moon test` 命令进行测试:
+
+```bash
+$ moon test
+Total tests: 1, passed: 1, failed: 0.
+```
+
 ## 包导入
 
 在 MoonBit 的构建系统中，模块的名称用来引用其内部包。

--- a/zh-docs/build-system-tutorial.md
+++ b/zh-docs/build-system-tutorial.md
@@ -102,7 +102,13 @@ my-project
 
   ```json
   {
-    "name": "hello"
+    "name": "username/hello",
+    "version": "0.1.0",
+    "readme": "README.md",
+    "repository": "",
+    "license": "Apache-2.0",
+    "keywords": [],
+    "description": ""
   }
   ```
 


### PR DESCRIPTION
This PR addresses a minor typo - it changes `raidus` to `radius` in both English and Chinese.

I also think that the `live` code blocks are a stroke of genius, and noticed as I was reading through the documentation that there were many places where I wanted to click on "Run" but it was missing.

I realize that not _all_ code blocks in the documentation are meant to be run, so I tried to be careful to add only the ones that _looked_ like they should be able to run, although I could not figure out how to test these changes out locally.
Any recommendations on testing would be greatly appreciated.

Additionally, my copy of VSCode has a plugin called [Markdown All in One](https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one) which automatically formats tables to be more readable when reading the Markdown source, which I think is a great idea, so I left those changes in this PR too. I hope you don't mind.

Thank you for the amazing language with excellent documentation, and I'm looking forward to learning more!