### PR TITLE
CI: Auto Sync json schema from moon & build markdown docs

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,0 +1,5 @@
+moonbitlang/moon:
+  - source: 'crates/moonbuild/template/mod.schema.json'
+    dest: 'mod.schema.json'
+  - source: 'crates/moonbuild/template/pkg.schema.json'
+    dest: 'pkg.schema.json'

--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,5 +1,0 @@
-moonbitlang/moon:
-  - source: 'crates/moonbuild/template/mod.schema.json'
-    dest: 'mod.schema.json'
-  - source: 'crates/moonbuild/template/pkg.schema.json'
-    dest: 'pkg.schema.json'

--- a/.github/workflows/sync-json-schema.yml
+++ b/.github/workflows/sync-json-schema.yml
@@ -1,25 +1,40 @@
 name: Sync Json Schema
 on:
   schedule:
-    - cron: '0 0 * * 2'
+    - cron: "0 0 * * 2"
   workflow_dispatch:
 jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Update JSON Schema
-      run: |
-        echo "[INFO] Getting JSON schema from moonbitlang/moon"
-        curl 'https://raw.githubusercontent.com/moonbitlang/moon/main/crates/moonbuild/template/pkg.schema.json' > pkg.schema.json
-        curl 'https://raw.githubusercontent.com/moonbitlang/moon/main/crates/moonbuild/template/mod.schema.json' > mod.schema.json
-    - name: Create PR based on changes
-      uses: peter-evans/create-pull-request@v6
-      with:
-        commit-message: Sync json schema from moon
-        title: sync json schema from moon
-        body: Automated changes by `sync-json-schema` action to sync json schema from moon
-        labels: |
-          bot
-        add-paths: |
-          *.schema.json
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Update JSON Schema
+        run: |
+          echo "[INFO] Getting JSON schema from moonbitlang/moon"
+          curl 'https://raw.githubusercontent.com/moonbitlang/moon/main/crates/moonbuild/template/pkg.schema.json' > pkg.schema.json
+          curl 'https://raw.githubusercontent.com/moonbitlang/moon/main/crates/moonbuild/template/mod.schema.json' > mod.schema.json
+
+      - name: Generate MD Doc based on JSON Schema
+        run: |
+          pip install jsonschema2md
+          jsonschema2md mod.schema.json mod.md
+          jsonschema2md pkg.schema.json pkg.md
+          cat mod.md pkg.md > build-system-configuration.md
+          cp build-system-configuration.md zh-docs/build-system-configuration.md
+          rm mod.md pkg.md
+
+      - name: Create PR based on changes
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: Sync json schema & build docs from moon
+          title: "[Bot] sync json schema from moon"
+          body: Automated changes by `sync-json-schema` action to sync json schema and build markdown documentations from moon
+          labels: |
+            bot
+          add-paths: |
+            *.schema.json
+            build-system-configuration.md

--- a/.github/workflows/sync-json-schema.yml
+++ b/.github/workflows/sync-json-schema.yml
@@ -1,0 +1,15 @@
+name: Sync Json Schema
+on:
+  schedule:
+    - cron: '0 0 * * 2'
+  workflow_dispatch:
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@master
+      - name: Run GitHub File Sync
+        uses: hirotomoyamada/repo-file-sync-action@main
+        with:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/sync-json-schema.yml
+++ b/.github/workflows/sync-json-schema.yml
@@ -7,9 +7,19 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@master
-      - name: Run GitHub File Sync
-        uses: hirotomoyamada/repo-file-sync-action@main
-        with:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+    - uses: actions/checkout@v4
+    - name: Update JSON Schema
+      run: |
+        echo "[INFO] Getting JSON schema from moonbitlang/moon"
+        curl 'https://raw.githubusercontent.com/moonbitlang/moon/main/crates/moonbuild/template/pkg.schema.json' > pkg.schema.json
+        curl 'https://raw.githubusercontent.com/moonbitlang/moon/main/crates/moonbuild/template/mod.schema.json' > mod.schema.json
+    - name: Create PR based on changes
+      uses: peter-evans/create-pull-request@v6
+      with:
+        commit-message: Sync json schema from moon
+        title: sync json schema from moon
+        body: Automated changes by `sync-json-schema` action to sync json schema from moon
+        labels: |
+          bot
+        add-paths: |
+          *.schema.json

--- a/build-system-configuration.md
+++ b/build-system-configuration.md
@@ -1,675 +1,108 @@
-# MoonBit's Build System Configuration
-
-<!-- Generated with [json-schema-static-docs](https://tomcollins.github.io/json-schema-static-docs/) -->
-<!-- TODO: use docusaurus-json-schema-plugin -->
-
-## JSON schema for Moonbit moon.mod.json files
-
-<p>A module of Moonbit lang</p>
-
-<table>
-<tbody>
-
-<tr><th>$schema</th><td>http://json-schema.org/draft-07/schema#</td></tr>
-</tbody>
-</table>
-
-### Properties
-
-<table class="jssd-properties-table"><thead><tr><th colspan="2">Name</th><th>Type</th></tr></thead><tbody><tr><td colspan="2"><a href="#name">name</a></td><td>String</td></tr><tr><td colspan="2"><a href="#version">version</a></td><td>String</td></tr><tr><td colspan="2"><a href="#deps">deps</a></td><td>Object</td></tr><tr><td colspan="2"><a href="#readme">readme</a></td><td>String</td></tr><tr><td colspan="2"><a href="#repository">repository</a></td><td>String</td></tr><tr><td colspan="2"><a href="#license">license</a></td><td>String</td></tr></tbody></table>
-
-### name
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>Description</th>
-      <td colspan="2">Name of the module</td>
-    </tr>
-    <tr><th>Type</th><td colspan="2">String</td></tr>
-    <tr>
-      <th>Required</th>
-      <td colspan="2">Yes</td>
-    </tr>
-    
-  </tbody>
-</table>
-
-
-
-
-### version
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>Description</th>
-      <td colspan="2">Version of the module, following Semantic Versioning 2.0.0</td>
-    </tr>
-    <tr><th>Type</th><td colspan="2">String</td></tr>
-    <tr>
-      <th>Required</th>
-      <td colspan="2">No</td>
-    </tr>
-    
-  </tbody>
-</table>
-
-### deps
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>Description</th>
-      <td colspan="2">Third-party dependencies of the module</td>
-    </tr>
-    <tr><th>Type</th><td colspan="2">Object</td></tr>
-    <tr>
-      <th>Required</th>
-      <td colspan="2">No</td>
-    </tr>
-    
-  </tbody>
-</table>
-
-### readme
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>Description</th>
-      <td colspan="2">Path to module&#x27;s README file</td>
-    </tr>
-    <tr><th>Type</th><td colspan="2">String</td></tr>
-    <tr>
-      <th>Required</th>
-      <td colspan="2">No</td>
-    </tr>
-    
-  </tbody>
-</table>
-
-### repository
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>Description</th>
-      <td colspan="2">URL to module&#x27;s repository</td>
-    </tr>
-    <tr><th>Type</th><td colspan="2">String</td></tr>
-    <tr>
-      <th>Required</th>
-      <td colspan="2">No</td>
-    </tr>
-    <tr>
-      <th>Format</th>
-      <td colspan="2">uri</td>
-    </tr>
-  </tbody>
-</table>
-
-### license
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>Description</th>
-      <td colspan="2">License of the module, an SPDX identifier</td>
-    </tr>
-    <tr><th>Type</th><td colspan="2">String</td></tr>
-    <tr>
-      <th>Required</th>
-      <td colspan="2">No</td>
-    </tr>
-    
-  </tbody>
-</table>
-
-### Schema
-```
-{
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "JSON schema for Moonbit moon.mod.json files",
-    "description": "A module of Moonbit lang",
-    "type": "object",
-    "properties": {
-        "name": {
-            "description": "Name of the module",
-            "type": "string"
-        },
-        "version": {
-            "description": "Version of the module, following Semantic Versioning 2.0.0",
-            "type": "string"
-        },
-        "deps": {
-            "description": "Third-party dependencies of the module",
-            "type": "object",
-            "additionalProperties": {
-                "type": "string"
-            }
-        },
-        "readme": {
-            "description": "Path to module's README file",
-            "type": "string"
-        },
-        "repository": {
-            "description": "URL to module's repository",
-            "type": "string",
-            "format": "uri"
-        },
-        "license": {
-            "description": "License of the module, an SPDX identifier",
-            "type": "string"
-        }
-    },
-    "required": [
-        "name"
-    ]
-}
-```
-
-## JSON schema for Moonbit moon.pkg.json files
-
-<p>A package in Moonbit lang</p>
-
-<table>
-<tbody>
-
-<tr><th>$schema</th><td>http://json-schema.org/draft-07/schema#</td></tr>
-</tbody>
-</table>
-
-### Properties
-
-<table class="jssd-properties-table"><thead><tr><th colspan="2">Name</th><th>Type</th></tr></thead><tbody><tr><td colspan="2"><a href="#name">name</a></td><td>String</td></tr><tr><td colspan="2"><a href="#is-main">is-main</a></td><td>Boolean</td></tr><tr><th rowspan="2">import</th><td rowspan="2">One of:</td><td>Object</td></tr><tr><td>Array</td></tr><tr><th rowspan="2">link</th><td rowspan="2">One of:</td><td>Boolean</td></tr><tr><td>Object</td></tr></tbody></table>
-
-### name
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>Description</th>
-      <td colspan="2">Name of the package (Deprecated)</td>
-    </tr>
-    <tr><th>Type</th><td colspan="2">String</td></tr>
-    <tr>
-      <th>Required</th>
-      <td colspan="2">No</td>
-    </tr>
-    
-  </tbody>
-</table>
-
-
-
-
-### is-main
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>Description</th>
-      <td colspan="2">Specify whether this package is a main package or not</td>
-    </tr>
-    <tr><th>Type</th><td colspan="2">Boolean</td></tr>
-    <tr>
-      <th>Required</th>
-      <td colspan="2">No</td>
-    </tr>
-    
-  </tbody>
-</table>
-
-
-
-
-### import
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>Description</th>
-      <td colspan="2">Imported packages of the package</td>
-    </tr>
-    <tr><tr><th rowspan="2">Type</th><td rowspan="2">One of:</td><td>Object</td></tr><tr><td>Array</td></tr></tr>
-    <tr>
-      <th>Required</th>
-      <td colspan="2">No</td>
-    </tr>
-    
-  </tbody>
-</table>
-
-
-
-#### import.0
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>Title</th>
-      <td colspan="2">Object form</td>
-    </tr>
-    <tr><th>Type</th><td colspan="2">Object</td></tr>
-    
-  </tbody>
-</table>
-
-
-
-
-#### import.1
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>Title</th>
-      <td colspan="2">Array form</td>
-    </tr>
-    <tr><th>Type</th><td colspan="2">Array</td></tr>
-    
-  </tbody>
-</table>
-
-### link
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr><tr><th rowspan="2">Type</th><td rowspan="2">One of:</td><td>Boolean</td></tr><tr><td>Object</td></tr></tr>
-    <tr>
-      <th>Required</th>
-      <td colspan="2">No</td>
-    </tr>
-    
-  </tbody>
-</table>
-
-
-
-#### link.0
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>Title</th>
-      <td colspan="2">Build this package</td>
-    </tr>
-    <tr><th>Type</th><td colspan="2">Boolean</td></tr>
-    
-  </tbody>
-</table>
-
-
-
-
-#### link.1
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>Title</th>
-      <td colspan="2">Build configuration</td>
-    </tr>
-    <tr>
-      <th>Description</th>
-      <td colspan="2">Configure the build for each backend</td>
-    </tr>
-    <tr><th>Type</th><td colspan="2">Object</td></tr>
-    
-  </tbody>
-</table>
-
-
-
-#### link.1.wasm
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr><th>Type</th><td colspan="2">Object</td></tr>
-    
-  </tbody>
-</table>
-
-
-
-#### link.1.wasm.exports
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>Description</th>
-      <td colspan="2">Exported functions of the package</td>
-    </tr>
-    <tr><th>Type</th><td colspan="2">Array</td></tr>
-    
-  </tbody>
-</table>
-
-
-
-
-#### link.1.wasm.export-memory-name
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>Description</th>
-      <td colspan="2">Name of the exported memory, or no memory will be exported</td>
-    </tr>
-    <tr><th>Type</th><td colspan="2">String</td></tr>
-    
-  </tbody>
-</table>
-
-
-
-
-#### link.1.wasm.flags
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>Description</th>
-      <td colspan="2">Flags for the compilation of the package</td>
-    </tr>
-    <tr><th>Type</th><td colspan="2">Array</td></tr>
-    
-  </tbody>
-</table>
-
-
-
-
-
-#### link.1.wasm-gc
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr><th>Type</th><td colspan="2">Object</td></tr>
-    
-  </tbody>
-</table>
-
-
-
-#### link.1.wasm-gc.exports
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>Description</th>
-      <td colspan="2">Exported functions of the package</td>
-    </tr>
-    <tr><th>Type</th><td colspan="2">Array</td></tr>
-    
-  </tbody>
-</table>
-
-
-
-
-#### link.1.wasm-gc.export-memory-name
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>Description</th>
-      <td colspan="2">Name of the exported memory, or no memory will be exported</td>
-    </tr>
-    <tr><th>Type</th><td colspan="2">String</td></tr>
-    
-  </tbody>
-</table>
-
-
-
-
-#### link.1.wasm-gc.flags
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>Description</th>
-      <td colspan="2">Flags for the compilation of the package</td>
-    </tr>
-    <tr><th>Type</th><td colspan="2">Array</td></tr>
-    
-  </tbody>
-</table>
-
-
-
-
-
-#### link.1.js
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr><th>Type</th><td colspan="2">Object</td></tr>
-    
-  </tbody>
-</table>
-
-
-
-#### link.1.js.exports
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>Description</th>
-      <td colspan="2">Exported functions of the package</td>
-    </tr>
-    <tr><th>Type</th><td colspan="2">Array</td></tr>
-    
-  </tbody>
-</table>
-
-
-
-
-#### link.1.js.format
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>Description</th>
-      <td colspan="2">Format of the output JavaScript file</td>
-    </tr>
-    
-    <tr>
-      <th>Enum</th>
-      <td colspan="2"><ul><li>esm</li><li>cjs</li><li>iife</li></ul></td>
-    </tr>
-  </tbody>
-</table>
-
-### Schema
-```
-{
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "JSON schema for Moonbit moon.pkg.json files",
-    "description": "A package in Moonbit lang",
-    "type": "object",
-    "properties": {
-        "name": {
-            "description": "Name of the package (Deprecated)",
-            "type": "string"
-        },
-        "is-main": {
-            "description": "Specify whether this package is a main package or not",
-            "type": "boolean",
-            "default": false
-        },
-        "import": {
-            "description": "Imported packages of the package",
-            "oneOf": [
-                {
-                    "title": "Object form",
-                    "type": "object",
-                    "additionalProperties": {
-                        "description": "Path and alias of an imported package",
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    }
-                },
-                {
-                    "title": "Array form",
-                    "type": "array",
-                    "items": {
-                        "oneOf": [
-                            {
-                                "title": "Package without alias",
-                                "description": "Path of an imported package",
-                                "type": "string"
-                            },
-                            {
-                                "title": "Package with alias",
-                                "description": "Path and alias of an imported package",
-                                "type": "object",
-                                "properties": {
-                                    "path": {
-                                        "description": "Path of an imported package",
-                                        "type": "string"
-                                    },
-                                    "alias": {
-                                        "description": "Alias of an imported package",
-                                        "type": "string"
-                                    }
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                    "path",
-                                    "alias"
-                                ]
-                            }
-                        ]
-                    }
-                }
-            ]
-        },
-        "link": {
-            "oneOf": [
-                {
-                    "title": "Build this package",
-                    "type": "boolean"
-                },
-                {
-                    "title": "Build configuration",
-                    "description": "Configure the build for each backend",
-                    "type": "object",
-                    "properties": {
-                        "wasm": {
-                            "type": "object",
-                            "properties": {
-                                "exports": {
-                                    "description": "Exported functions of the package",
-                                    "type": "array",
-                                    "items": {
-                                        "description": "Name of an exported function, or followed by a colon and the alias name",
-                                        "type": "string"
-                                    }
-                                },
-                                "export-memory-name": {
-                                    "description": "Name of the exported memory, or no memory will be exported",
-                                    "type": "string"
-                                },
-                                "flags": {
-                                    "description": "Flags for the compilation of the package",
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string",
-                                        "enum": [
-                                            "-no-block-params"
-                                        ]
-                                    }
-                                }
-                            },
-                            "additionalProperties": false
-                        },
-                        "wasm-gc": {
-                            "type": "object",
-                            "properties": {
-                                "exports": {
-                                    "description": "Exported functions of the package",
-                                    "type": "array",
-                                    "items": {
-                                        "description": "Name of an exported function, or followed by a colon and the alias name",
-                                        "type": "string"
-                                    }
-                                },
-                                "export-memory-name": {
-                                    "description": "Name of the exported memory, or no memory will be exported",
-                                    "type": "string"
-                                },
-                                "flags": {
-                                    "description": "Flags for the compilation of the package",
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string",
-                                        "enum": [
-                                            "-no-block-params"
-                                        ]
-                                    }
-                                }
-                            },
-                            "additionalProperties": false
-                        },
-                        "js": {
-                            "type": "object",
-                            "properties": {
-                                "exports": {
-                                    "description": "Exported functions of the package",
-                                    "type": "array",
-                                    "items": {
-                                        "description": "Name of an exported function, or followed by a colon and the alias name",
-                                        "type": "string"
-                                    }
-                                },
-                                "format": {
-                                    "description": "Format of the output JavaScript file",
-                                    "enum": [
-                                        "esm",
-                                        "cjs",
-                                        "iife"
-                                    ]
-                                }
-                            },
-                            "additionalProperties": false
-                        }
-                    },
-                    "additionalProperties": false
-                }
-            ]
-        }
-    },
-    "required": []
-}
-```
-
-
+# JSON schema for MoonBit moon.mod.json files
+
+*A module of MoonBit lang*
+
+## Properties
+
+- **`alert-list`** *(['string', 'null'])*: Alert list setting of the module.
+- **`deps`** *(['object', 'null'])*: third-party dependencies of the module. Can contain additional properties.
+  - **Additional properties** *(string)*
+- **`description`** *(['string', 'null'])*: description of this module.
+- **`keywords`** *(['array', 'null'])*: keywords of this module.
+  - **Items** *(string)*
+- **`license`** *(['string', 'null'])*: license of this module.
+- **`name`** *(string, required)*: name of the module.
+- **`readme`** *(['string', 'null'])*: path to module's README file.
+- **`repository`** *(['string', 'null'])*: url to module's repository.
+- **`source`** *(['string', 'null'])*: source code directory of this module.
+- **`version`** *(['string', 'null'])*: version of the module.
+- **`warn-list`** *(['string', 'null'])*: Warn list setting of the module.
+# JSON schema for MoonBit moon.pkg.json files
+
+*A package of MoonBit language*
+
+## Properties
+
+- **`alert_list`** *(['string', 'null'])*: Alert list setting of the package.
+- **`import`**: Imported packages of the package.
+  - **Any of**
+    - : Refer to *[#/definitions/PkgJSONImport](#definitions/PkgJSONImport)*.
+    - *null*
+- **`is_main`** *(['boolean', 'null'])*: Specify whether this package is a main package or not.
+- **`link`**
+  - **Any of**
+    - : Refer to *[#/definitions/BoolOrLink](#definitions/BoolOrLink)*.
+    - *null*
+- **`name`** *(['string', 'null'])*
+- **`test_import`**: Black box test imported packages of the package.
+  - **Any of**
+    - : Refer to *[#/definitions/PkgJSONImport](#definitions/PkgJSONImport)*.
+    - *null*
+- **`warn_list`** *(['string', 'null'])*: Warn list setting of the package.
+- **`wbtest_import`**: White box test imported packages of the package.
+  - **Any of**
+    - : Refer to *[#/definitions/PkgJSONImport](#definitions/PkgJSONImport)*.
+    - *null*
+## Definitions
+
+- <a id="definitions/BoolOrLink"></a>**`BoolOrLink`**
+  - **Any of**
+    - *boolean*
+    - : Refer to *[#/definitions/Link](#definitions/Link)*.
+- <a id="definitions/ImportMemory"></a>**`ImportMemory`** *(object)*
+  - **`module`** *(string, required)*
+  - **`name`** *(string, required)*
+- <a id="definitions/JsFormat"></a>**`JsFormat`** *(string)*: Must be one of: `["esm", "cjs", "iife"]`.
+- <a id="definitions/JsLinkConfig"></a>**`JsLinkConfig`** *(object)*
+  - **`exports`** *(['array', 'null'])*
+    - **Items** *(string)*
+  - **`format`**
+    - **Any of**
+      - : Refer to *[#/definitions/JsFormat](#definitions/JsFormat)*.
+      - *null*
+- <a id="definitions/Link"></a>**`Link`** *(object)*
+  - **`js`**
+    - **Any of**
+      - : Refer to *[#/definitions/JsLinkConfig](#definitions/JsLinkConfig)*.
+      - *null*
+  - **`wasm`**
+    - **Any of**
+      - : Refer to *[#/definitions/WasmLinkConfig](#definitions/WasmLinkConfig)*.
+      - *null*
+  - **`wasm-gc`**
+    - **Any of**
+      - : Refer to *[#/definitions/WasmGcLinkConfig](#definitions/WasmGcLinkConfig)*.
+      - *null*
+- <a id="definitions/PkgJSONImport"></a>**`PkgJSONImport`**
+  - **Any of**
+    - *object*: Path and alias of an imported package. Can contain additional properties.
+      - **Additional properties** *(['string', 'null'])*
+    - *array*
+      - **Items**: Refer to *[#/definitions/PkgJSONImportItem](#definitions/PkgJSONImportItem)*.
+- <a id="definitions/PkgJSONImportItem"></a>**`PkgJSONImportItem`**
+  - **Any of**
+    - *string*
+    - *object*
+      - **`alias`** *(string, required)*
+      - **`path`** *(string, required)*
+- <a id="definitions/WasmGcLinkConfig"></a>**`WasmGcLinkConfig`** *(object)*
+  - **`export-memory-name`** *(['string', 'null'])*
+  - **`exports`** *(['array', 'null'])*
+    - **Items** *(string)*
+  - **`flags`** *(['array', 'null'])*
+    - **Items** *(string)*
+  - **`import-memory`**
+    - **Any of**
+      - : Refer to *[#/definitions/ImportMemory](#definitions/ImportMemory)*.
+      - *null*
+- <a id="definitions/WasmLinkConfig"></a>**`WasmLinkConfig`** *(object)*
+  - **`export-memory-name`** *(['string', 'null'])*
+  - **`exports`** *(['array', 'null'])*
+    - **Items** *(string)*
+  - **`flags`** *(['array', 'null'])*
+    - **Items** *(string)*
+  - **`heap-start-address`** *(['integer', 'null'], format: uint32)*: Minimum: `0.0`.
+  - **`import-memory`**
+    - **Any of**
+      - : Refer to *[#/definitions/ImportMemory](#definitions/ImportMemory)*.
+      - *null*

--- a/mod.schema.json
+++ b/mod.schema.json
@@ -1,39 +1,91 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "JSON schema for Moonbit moon.mod.json files",
-  "description": "A module of Moonbit lang",
+  "title": "JSON schema for MoonBit moon.mod.json files",
+  "description": "A module of MoonBit lang",
   "type": "object",
+  "required": [
+    "name"
+  ],
   "properties": {
-    "name": {
-      "description": "Name of the module",
-      "type": "string"
-    },
-    "version": {
-      "description": "Version of the module, following Semantic Versioning 2.0.0",
-      "type": "string"
+    "alert-list": {
+      "description": "Alert list setting of the module",
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "deps": {
-      "description": "Third-party dependencies of the module",
-      "type": "object",
+      "description": "third-party dependencies of the module",
+      "type": [
+        "object",
+        "null"
+      ],
       "additionalProperties": {
         "type": "string"
       }
     },
-    "readme": {
-      "description": "Path to module's README file",
-      "type": "string"
+    "description": {
+      "description": "description of this module",
+      "type": [
+        "string",
+        "null"
+      ]
     },
-    "repository": {
-      "description": "URL to module's repository",
-      "type": "string",
-      "format": "uri"
+    "keywords": {
+      "description": "keywords of this module",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
     },
     "license": {
-      "description": "License of the module, an SPDX identifier",
+      "description": "license of this module",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "name": {
+      "description": "name of the module",
       "type": "string"
+    },
+    "readme": {
+      "description": "path to module's README file",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "repository": {
+      "description": "url to module's repository",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "source": {
+      "description": "source code directory of this module",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "version": {
+      "description": "version of the module",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "warn-list": {
+      "description": "Warn list setting of the module",
+      "type": [
+        "string",
+        "null"
+      ]
     }
-  },
-  "required": [
-    "name"
-  ]
+  }
 }

--- a/pkg.schema.json
+++ b/pkg.schema.json
@@ -1,26 +1,179 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "JSON schema for Moonbit moon.pkg.json files",
-  "description": "A package in Moonbit lang",
+  "title": "JSON schema for MoonBit moon.pkg.json files",
+  "description": "A package of MoonBit language",
   "type": "object",
   "properties": {
-    "name": {
-      "description": "Name of the package (Deprecated)",
-      "type": "string"
-    },
-    "is-main": {
-      "description": "Specify whether this package is a main package or not",
-      "type": "boolean",
-      "default": false
+    "alert_list": {
+      "description": "Alert list setting of the package",
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "import": {
       "description": "Imported packages of the package",
-      "oneOf": [
+      "anyOf": [
         {
-          "title": "Object form",
+          "$ref": "#/definitions/PkgJSONImport"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "is_main": {
+      "description": "Specify whether this package is a main package or not",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/BoolOrLink"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "name": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "test_import": {
+      "description": "Black box test imported packages of the package",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/PkgJSONImport"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "warn_list": {
+      "description": "Warn list setting of the package",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "wbtest_import": {
+      "description": "White box test imported packages of the package",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/PkgJSONImport"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "BoolOrLink": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/Link"
+        }
+      ]
+    },
+    "ImportMemory": {
+      "type": "object",
+      "required": [
+        "module",
+        "name"
+      ],
+      "properties": {
+        "module": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "JsFormat": {
+      "type": "string",
+      "enum": [
+        "esm",
+        "cjs",
+        "iife"
+      ]
+    },
+    "JsLinkConfig": {
+      "type": "object",
+      "properties": {
+        "exports": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "format": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/JsFormat"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "Link": {
+      "type": "object",
+      "properties": {
+        "js": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/JsLinkConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "wasm": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WasmLinkConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "wasm-gc": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WasmGcLinkConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "PkgJSONImport": {
+      "anyOf": [
+        {
+          "description": "Path and alias of an imported package",
           "type": "object",
           "additionalProperties": {
-            "description": "Path and alias of an imported package",
             "type": [
               "string",
               "null"
@@ -28,134 +181,120 @@
           }
         },
         {
-          "title": "Array form",
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "title": "Package without alias",
-                "description": "Path of an imported package",
-                "type": "string"
-              },
-              {
-                "title": "Package with alias",
-                "description": "Path and alias of an imported package",
-                "type": "object",
-                "properties": {
-                  "path": {
-                    "description": "Path of an imported package",
-                    "type": "string"
-                  },
-                  "alias": {
-                    "description": "Alias of an imported package",
-                    "type": "string"
-                  }
-                },
-                "additionalProperties": false,
-                "required": [
-                  "path",
-                  "alias"
-                ]
-              }
-            ]
+            "$ref": "#/definitions/PkgJSONImportItem"
           }
         }
       ]
     },
-    "link": {
-      "oneOf": [
+    "PkgJSONImportItem": {
+      "anyOf": [
         {
-          "title": "Build this package",
-          "type": "boolean"
+          "type": "string"
         },
         {
-          "title": "Build configuration",
-          "description": "Configure the build for each backend",
           "type": "object",
+          "required": [
+            "alias",
+            "path"
+          ],
           "properties": {
-            "wasm": {
-              "type": "object",
-              "properties": {
-                "exports": {
-                  "description": "Exported functions of the package",
-                  "type": "array",
-                  "items": {
-                    "description": "Name of an exported function, or followed by a colon and the alias name",
-                    "type": "string"
-                  }
-                },
-                "export-memory-name": {
-                  "description": "Name of the exported memory, or no memory will be exported",
-                  "type": "string"
-                },
-                "flags": {
-                  "description": "Flags for the compilation of the package",
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "enum": [
-                      "-no-block-params"
-                    ]
-                  }
-                }
-              },
-              "additionalProperties": false
+            "alias": {
+              "type": "string"
             },
-            "wasm-gc": {
-              "type": "object",
-              "properties": {
-                "exports": {
-                  "description": "Exported functions of the package",
-                  "type": "array",
-                  "items": {
-                    "description": "Name of an exported function, or followed by a colon and the alias name",
-                    "type": "string"
-                  }
-                },
-                "export-memory-name": {
-                  "description": "Name of the exported memory, or no memory will be exported",
-                  "type": "string"
-                },
-                "flags": {
-                  "description": "Flags for the compilation of the package",
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "enum": [
-                      "-no-block-params"
-                    ]
-                  }
-                }
-              },
-              "additionalProperties": false
-            },
-            "js": {
-              "type": "object",
-              "properties": {
-                "exports": {
-                  "description": "Exported functions of the package",
-                  "type": "array",
-                  "items": {
-                    "description": "Name of an exported function, or followed by a colon and the alias name",
-                    "type": "string"
-                  }
-                },
-                "format": {
-                  "description": "Format of the output JavaScript file",
-                  "enum": [
-                    "esm",
-                    "cjs",
-                    "iife"
-                  ]
-                }
-              },
-              "additionalProperties": false
+            "path": {
+              "type": "string"
             }
-          },
-          "additionalProperties": false
+          }
         }
       ]
+    },
+    "WasmGcLinkConfig": {
+      "type": "object",
+      "properties": {
+        "export-memory-name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "exports": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "flags": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "import-memory": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ImportMemory"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "WasmLinkConfig": {
+      "type": "object",
+      "properties": {
+        "export-memory-name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "exports": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "flags": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "heap-start-address": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "import-memory": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ImportMemory"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
     }
-  },
-  "required": []
+  }
 }

--- a/zh-docs/build-system-configuration.md
+++ b/zh-docs/build-system-configuration.md
@@ -1,673 +1,108 @@
-# MoonBit 构建系统配置
-
-<!-- Generated with [json-schema-static-docs](https://tomcollins.github.io/json-schema-static-docs/) -->
-<!-- TODO: use docusaurus-json-schema-plugin -->
-
-## moon.mod.json的JSON Schema
-
-<p>月兔的一个模块</p>
-
-<table>
-<tbody>
-
-<tr><th>$schema</th><td>http://json-schema.org/draft-07/schema#</td></tr>
-</tbody>
-</table>
-
-### 属性
-
-<table class="jssd-properties-table"><thead><tr><th colspan="2">名称</th><th>类型</th></tr></thead><tbody><tr><td colspan="2"><a href="#name">name</a></td><td>String</td></tr><tr><td colspan="2"><a href="#version">version</a></td><td>String</td></tr><tr><td colspan="2"><a href="#deps">deps</a></td><td>Object</td></tr><tr><td colspan="2"><a href="#readme">readme</a></td><td>String</td></tr><tr><td colspan="2"><a href="#repository">repository</a></td><td>String</td></tr><tr><td colspan="2"><a href="#license">license</a></td><td>String</td></tr></tbody></table>
-
-### name
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>描述</th>
-      <td colspan="2">模块名称</td>
-    </tr>
-    <tr><th>类型</th><td colspan="2">String</td></tr>
-    <tr>
-      <th>必填</th>
-      <td colspan="2">是</td>
-    </tr>
-    
-  </tbody>
-</table>
-
-### version
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>描述</th>
-      <td colspan="2">模块版本号，遵循 Semantic Versioning 2.0.0</td>
-    </tr>
-    <tr><th>类型</th><td colspan="2">String</td></tr>
-    <tr>
-      <th>必填</th>
-      <td colspan="2">否</td>
-    </tr>
-    
-  </tbody>
-</table>
-
-### deps
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>描述</th>
-      <td colspan="2">模块的第三方依赖</td>
-    </tr>
-    <tr><th>类型</th><td colspan="2">Object</td></tr>
-    <tr>
-      <th>必填</th>
-      <td colspan="2">否</td>
-    </tr>
-    
-  </tbody>
-</table>
-
-### readme
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>描述</th>
-      <td colspan="2">模块“读我“文件路径</td>
-    </tr>
-    <tr><th>类型</th><td colspan="2">字符串</td></tr>
-    <tr>
-      <th>必填</th>
-      <td colspan="2">否</td>
-    </tr>
-    
-  </tbody>
-</table>
-
-### repository
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>描述</th>
-      <td colspan="2">模块仓库链接</td>
-    </tr>
-    <tr><th>类型</th><td colspan="2">String</td></tr>
-    <tr>
-      <th>必填</th>
-      <td colspan="2">否</td>
-    </tr>
-    <tr>
-      <th>格式</th>
-      <td colspan="2">uri</td>
-    </tr>
-  </tbody>
-</table>
-
-### license
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>描述</th>
-      <td colspan="2">模块的许可证，一个SPDX标识符</td>
-    </tr>
-    <tr><th>类型</th><td colspan="2">String</td></tr>
-    <tr>
-      <th>必填</th>
-      <td colspan="2">否</td>
-    </tr>
-    
-  </tbody>
-</table>
-
-### Schema
-```
-{
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "JSON schema for Moonbit moon.mod.json files",
-    "description": "A module of Moonbit lang",
-    "type": "object",
-    "properties": {
-        "name": {
-            "description": "Name of the module",
-            "type": "string"
-        },
-        "version": {
-            "description": "Version of the module, following Semantic Versioning 2.0.0",
-            "type": "string"
-        },
-        "deps": {
-            "description": "Third-party dependencies of the module",
-            "type": "object",
-            "additionalProperties": {
-                "type": "string"
-            }
-        },
-        "readme": {
-            "description": "Path to module's README file",
-            "type": "string"
-        },
-        "repository": {
-            "description": "URL to module's repository",
-            "type": "string",
-            "format": "uri"
-        },
-        "license": {
-            "description": "License of the module, an SPDX identifier",
-            "type": "string"
-        }
-    },
-    "required": [
-        "name"
-    ]
-}
-```
-
-## moon.pkg.json的JSON Schema
-
-<p>月兔的一个包</p>
-
-<table>
-<tbody>
-
-<tr><th>$schema</th><td>http://json-schema.org/draft-07/schema#</td></tr>
-</tbody>
-</table>
-### 属性
-
-<table class="jssd-properties-table"><thead><tr><th colspan="2">名称</th><th>类型</th></tr></thead><tbody><tr><td colspan="2"><a href="#name">name</a></td><td>字符串</td></tr><tr><td colspan="2"><a href="#is-main">is-main</a></td><td>布尔值</td></tr><tr><th rowspan="2">import</th><td rowspan="2">其中之一：</td><td>对象</td></tr><tr><td>数组</td></tr><tr><th rowspan="2">link</th><td rowspan="2">其中之一：</td><td>布尔值</td></tr><tr><td>对象</td></tr></tbody></table>
-
-### name
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>描述</th>
-      <td colspan="2">包的名称（已弃用）</td>
-    </tr>
-    <tr><th>类型</th><td colspan="2">字符串</td></tr>
-    <tr>
-      <th>必需</th>
-      <td colspan="2">否</td>
-    </tr>
-    
-  </tbody>
-</table>
-
-
-
-
-### is-main
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>描述</th>
-      <td colspan="2">指定该包是否为主包</td>
-    </tr>
-    <tr><th>类型</th><td colspan="2">布尔值</td></tr>
-    <tr>
-      <th>必需</th>
-      <td colspan="2">否</td>
-    </tr>
-    
-  </tbody>
-</table>
-
-
-
-
-### import
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>描述</th>
-      <td colspan="2">导入的包</td>
-    </tr>
-    <tr><tr><th rowspan="2">类型</th><td rowspan="2">其中之一：</td><td>对象</td></tr><tr><td>数组</td></tr></tr>
-    <tr>
-      <th>必需</th>
-      <td colspan="2">否</td>
-    </tr>
-    
-  </tbody>
-</table>
-
-
-
-#### import.0
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>标题</th>
-      <td colspan="2">对象形式</td>
-    </tr>
-    <tr><th>类型</th><td colspan="2">对象</td></tr>
-    
-  </tbody>
-</table>
-
-
-
-
-#### import.1
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>标题</th>
-      <td colspan="2">数组形式</td>
-    </tr>
-    <tr><th>类型</th><td colspan="2">数组</td></tr>
-    
-  </tbody>
-</table>
-
-### link
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr><tr><th rowspan="2">类型</th><td rowspan="2">其中之一：</td><td>布尔值</td></tr><tr><td>对象</td></tr></tr>
-    <tr>
-      <th>必需</th>
-      <td colspan="2">否</td>
-    </tr>
-    
-  </tbody>
-</table>
-
-
-
-#### link.0
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>标题</th>
-      <td colspan="2">构建此包</td>
-    </tr>
-    <tr><th>类型</th><td colspan="2">布尔值</td></tr>
-    
-  </tbody>
-</table>
-
-
-
-
-#### link.1
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>标题</th>
-      <td colspan="2">构建配置</td>
-    </tr>
-    <tr>
-      <th>描述</th>
-      <td colspan="2">为每个后端配置构建</td>
-    </tr>
-    <tr><th>类型</th><td colspan="2">对象</td></tr>
-    
-  </tbody>
-</table>
-
-
-
-#### link.1.wasm
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr><th>类型</th><td colspan="2">对象</td></tr>
-    
-  </tbody>
-</table>
-
-
-
-#### link.1.wasm.exports
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>描述</th>
-      <td colspan="2">包的导出函数</td>
-    </tr>
-    <tr><th>类型</th><td colspan="2">数组</td></tr>
-    
-  </tbody>
-</table>
-
-
-
-
-#### link.1.wasm.export-memory-name
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>描述</th>
-      <td colspan="2">导出的内存的名称，或者不导出内存</td>
-    </tr>
-    <tr><th>类型</th><td colspan="2">字符串</td></tr>
-    
-  </tbody>
-</table>
-
-
-
-
-#### link.1.wasm.flags
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>描述</th>
-      <td colspan="2">包的编译标志</td>
-    </tr>
-    <tr><th>类型</th><td colspan="2">数组</td></tr>
-    
-  </tbody>
-</table>
-
-
-
-
-
-#### link.1.wasm-gc
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr><th>类型</th><td colspan="2">对象</td></tr>
-    
-  </tbody>
-</table>
-
-
-
-#### link.1.wasm-gc.exports
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>描述</th>
-      <td colspan="2">包的导出函数</td>
-    </tr>
-    <tr><th>类型</th><td colspan="2">数组</td></tr>
-    
-  </tbody>
-</table>
-
-
-
-
-#### link.1.wasm-gc.export-memory-name
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>描述</th>
-      <td colspan="2">导出的内存的名称，或者不导出内存</td>
-    </tr>
-    <tr><th>类型</th><td colspan="2">字符串</td></tr>
-    
-  </tbody>
-</table>
-
-
-
-
-#### link.1.wasm-gc.flags
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>描述</th>
-      <td colspan="2">包的编译标志</td>
-    </tr>
-    <tr><th>类型</th><td colspan="2">数组</td></tr>
-    
-  </tbody>
-</table>
-
-
-
-
-
-#### link.1.js
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr><th>类型</th><td colspan="2">对象</td></tr>
-    
-  </tbody>
-</table>
-
-
-
-#### link.1.js.exports
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>描述</th>
-      <td colspan="2">包的导出函数</td>
-    </tr>
-    <tr><th>类型</th><td colspan="2">数组</td></tr>
-    
-  </tbody>
-</table>
-
-
-
-
-#### link.1.js.format
-
-
-<table class="jssd-property-table">
-  <tbody>
-    <tr>
-      <th>描述</th>
-      <td colspan="2">输出 JavaScript 文件的格式</td>
-    </tr>
-    <tr>
-      <th>枚举</th>
-      <td colspan="2"><ul><li>esm</li><li>cjs</li><li>iife</li></ul></td>
-    </tr>
-  </tbody>
-</table>
-
-### 模式
-
-### Schema
-```
-{
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "JSON schema for Moonbit moon.pkg.json files",
-    "description": "A package in Moonbit lang",
-    "type": "object",
-    "properties": {
-        "name": {
-            "description": "Name of the package (Deprecated)",
-            "type": "string"
-        },
-        "is-main": {
-            "description": "Specify whether this package is a main package or not",
-            "type": "boolean",
-            "default": false
-        },
-        "import": {
-            "description": "Imported packages of the package",
-            "oneOf": [
-                {
-                    "title": "Object form",
-                    "type": "object",
-                    "additionalProperties": {
-                        "description": "Path and alias of an imported package",
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    }
-                },
-                {
-                    "title": "Array form",
-                    "type": "array",
-                    "items": {
-                        "oneOf": [
-                            {
-                                "title": "Package without alias",
-                                "description": "Path of an imported package",
-                                "type": "string"
-                            },
-                            {
-                                "title": "Package with alias",
-                                "description": "Path and alias of an imported package",
-                                "type": "object",
-                                "properties": {
-                                    "path": {
-                                        "description": "Path of an imported package",
-                                        "type": "string"
-                                    },
-                                    "alias": {
-                                        "description": "Alias of an imported package",
-                                        "type": "string"
-                                    }
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                    "path",
-                                    "alias"
-                                ]
-                            }
-                        ]
-                    }
-                }
-            ]
-        },
-        "link": {
-            "oneOf": [
-                {
-                    "title": "Build this package",
-                    "type": "boolean"
-                },
-                {
-                    "title": "Build configuration",
-                    "description": "Configure the build for each backend",
-                    "type": "object",
-                    "properties": {
-                        "wasm": {
-                            "type": "object",
-                            "properties": {
-                                "exports": {
-                                    "description": "Exported functions of the package",
-                                    "type": "array",
-                                    "items": {
-                                        "description": "Name of an exported function, or followed by a colon and the alias name",
-                                        "type": "string"
-                                    }
-                                },
-                                "export-memory-name": {
-                                    "description": "Name of the exported memory, or no memory will be exported",
-                                    "type": "string"
-                                },
-                                "flags": {
-                                    "description": "Flags for the compilation of the package",
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string",
-                                        "enum": [
-                                            "-no-block-params"
-                                        ]
-                                    }
-                                }
-                            },
-                            "additionalProperties": false
-                        },
-                        "wasm-gc": {
-                            "type": "object",
-                            "properties": {
-                                "exports": {
-                                    "description": "Exported functions of the package",
-                                    "type": "array",
-                                    "items": {
-                                        "description": "Name of an exported function, or followed by a colon and the alias name",
-                                        "type": "string"
-                                    }
-                                },
-                                "export-memory-name": {
-                                    "description": "Name of the exported memory, or no memory will be exported",
-                                    "type": "string"
-                                },
-                                "flags": {
-                                    "description": "Flags for the compilation of the package",
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string",
-                                        "enum": [
-                                            "-no-block-params"
-                                        ]
-                                    }
-                                }
-                            },
-                            "additionalProperties": false
-                        },
-                        "js": {
-                            "type": "object",
-                            "properties": {
-                                "exports": {
-                                    "description": "Exported functions of the package",
-                                    "type": "array",
-                                    "items": {
-                                        "description": "Name of an exported function, or followed by a colon and the alias name",
-                                        "type": "string"
-                                    }
-                                },
-                                "format": {
-                                    "description": "Format of the output JavaScript file",
-                                    "enum": [
-                                        "esm",
-                                        "cjs",
-                                        "iife"
-                                    ]
-                                }
-                            },
-                            "additionalProperties": false
-                        }
-                    },
-                    "additionalProperties": false
-                }
-            ]
-        }
-    },
-    "required": []
-}
-```
-
-
-
+# JSON schema for MoonBit moon.mod.json files
+
+*A module of MoonBit lang*
+
+## Properties
+
+- **`alert-list`** *(['string', 'null'])*: Alert list setting of the module.
+- **`deps`** *(['object', 'null'])*: third-party dependencies of the module. Can contain additional properties.
+  - **Additional properties** *(string)*
+- **`description`** *(['string', 'null'])*: description of this module.
+- **`keywords`** *(['array', 'null'])*: keywords of this module.
+  - **Items** *(string)*
+- **`license`** *(['string', 'null'])*: license of this module.
+- **`name`** *(string, required)*: name of the module.
+- **`readme`** *(['string', 'null'])*: path to module's README file.
+- **`repository`** *(['string', 'null'])*: url to module's repository.
+- **`source`** *(['string', 'null'])*: source code directory of this module.
+- **`version`** *(['string', 'null'])*: version of the module.
+- **`warn-list`** *(['string', 'null'])*: Warn list setting of the module.
+# JSON schema for MoonBit moon.pkg.json files
+
+*A package of MoonBit language*
+
+## Properties
+
+- **`alert_list`** *(['string', 'null'])*: Alert list setting of the package.
+- **`import`**: Imported packages of the package.
+  - **Any of**
+    - : Refer to *[#/definitions/PkgJSONImport](#definitions/PkgJSONImport)*.
+    - *null*
+- **`is_main`** *(['boolean', 'null'])*: Specify whether this package is a main package or not.
+- **`link`**
+  - **Any of**
+    - : Refer to *[#/definitions/BoolOrLink](#definitions/BoolOrLink)*.
+    - *null*
+- **`name`** *(['string', 'null'])*
+- **`test_import`**: Black box test imported packages of the package.
+  - **Any of**
+    - : Refer to *[#/definitions/PkgJSONImport](#definitions/PkgJSONImport)*.
+    - *null*
+- **`warn_list`** *(['string', 'null'])*: Warn list setting of the package.
+- **`wbtest_import`**: White box test imported packages of the package.
+  - **Any of**
+    - : Refer to *[#/definitions/PkgJSONImport](#definitions/PkgJSONImport)*.
+    - *null*
+## Definitions
+
+- <a id="definitions/BoolOrLink"></a>**`BoolOrLink`**
+  - **Any of**
+    - *boolean*
+    - : Refer to *[#/definitions/Link](#definitions/Link)*.
+- <a id="definitions/ImportMemory"></a>**`ImportMemory`** *(object)*
+  - **`module`** *(string, required)*
+  - **`name`** *(string, required)*
+- <a id="definitions/JsFormat"></a>**`JsFormat`** *(string)*: Must be one of: `["esm", "cjs", "iife"]`.
+- <a id="definitions/JsLinkConfig"></a>**`JsLinkConfig`** *(object)*
+  - **`exports`** *(['array', 'null'])*
+    - **Items** *(string)*
+  - **`format`**
+    - **Any of**
+      - : Refer to *[#/definitions/JsFormat](#definitions/JsFormat)*.
+      - *null*
+- <a id="definitions/Link"></a>**`Link`** *(object)*
+  - **`js`**
+    - **Any of**
+      - : Refer to *[#/definitions/JsLinkConfig](#definitions/JsLinkConfig)*.
+      - *null*
+  - **`wasm`**
+    - **Any of**
+      - : Refer to *[#/definitions/WasmLinkConfig](#definitions/WasmLinkConfig)*.
+      - *null*
+  - **`wasm-gc`**
+    - **Any of**
+      - : Refer to *[#/definitions/WasmGcLinkConfig](#definitions/WasmGcLinkConfig)*.
+      - *null*
+- <a id="definitions/PkgJSONImport"></a>**`PkgJSONImport`**
+  - **Any of**
+    - *object*: Path and alias of an imported package. Can contain additional properties.
+      - **Additional properties** *(['string', 'null'])*
+    - *array*
+      - **Items**: Refer to *[#/definitions/PkgJSONImportItem](#definitions/PkgJSONImportItem)*.
+- <a id="definitions/PkgJSONImportItem"></a>**`PkgJSONImportItem`**
+  - **Any of**
+    - *string*
+    - *object*
+      - **`alias`** *(string, required)*
+      - **`path`** *(string, required)*
+- <a id="definitions/WasmGcLinkConfig"></a>**`WasmGcLinkConfig`** *(object)*
+  - **`export-memory-name`** *(['string', 'null'])*
+  - **`exports`** *(['array', 'null'])*
+    - **Items** *(string)*
+  - **`flags`** *(['array', 'null'])*
+    - **Items** *(string)*
+  - **`import-memory`**
+    - **Any of**
+      - : Refer to *[#/definitions/ImportMemory](#definitions/ImportMemory)*.
+      - *null*
+- <a id="definitions/WasmLinkConfig"></a>**`WasmLinkConfig`** *(object)*
+  - **`export-memory-name`** *(['string', 'null'])*
+  - **`exports`** *(['array', 'null'])*
+    - **Items** *(string)*
+  - **`flags`** *(['array', 'null'])*
+    - **Items** *(string)*
+  - **`heap-start-address`** *(['integer', 'null'], format: uint32)*: Minimum: `0.0`.
+  - **`import-memory`**
+    - **Any of**
+      - : Refer to *[#/definitions/ImportMemory](#definitions/ImportMemory)*.
+      - *null*


### PR DESCRIPTION
The updated json schema and markdown docs themselves are included in this pr as well.

As I haven't find a good way to translate those markdown docs, chinese version is directly copied from the original.

JSON Schema auto update example:
https://github.com/notch1p/moonbit-docs/actions/runs/10347197977
https://github.com/notch1p/moonbit-docs/pull/2

markdown docs auto build example:
https://github.com/notch1p/moonbit-docs/pull/3
https://github.com/notch1p/moonbit-docs/actions/runs/10348725731