### PR TITLE
feat: add error codes index

### DIFF
--- a/next/language/error_codes/E0001.md
+++ b/next/language/error_codes/E0001.md
@@ -1,0 +1,9 @@
+# E0001
+
+There is an internal error occurred to the compiler. Usually this means you have
+discovered a bug in the compiler.
+
+A bug report containing the error description and relevant code would be
+greatly appreciated. You can submit the bug report here:
+
+<https://github.com/moonbitlang/moonbit-docs/issues/new?labels=bug,ICE>

--- a/next/language/error_codes/E1001.md
+++ b/next/language/error_codes/E1001.md
@@ -1,0 +1,3 @@
+# E1001
+
+Unused function.

--- a/next/language/error_codes/E1002.md
+++ b/next/language/error_codes/E1002.md
@@ -1,0 +1,3 @@
+# E1002
+
+Unused variable.

--- a/next/language/error_codes/E1003.md
+++ b/next/language/error_codes/E1003.md
@@ -1,0 +1,3 @@
+# E1003
+
+Unused type declaration.

--- a/next/language/error_codes/E1004.md
+++ b/next/language/error_codes/E1004.md
@@ -1,0 +1,3 @@
+# E1004
+
+Unused abstract type.

--- a/next/language/error_codes/E1005.md
+++ b/next/language/error_codes/E1005.md
@@ -1,0 +1,3 @@
+# E1005
+
+Unused generic type variable.

--- a/next/language/error_codes/E1006.md
+++ b/next/language/error_codes/E1006.md
@@ -1,0 +1,3 @@
+# E1006
+
+Variant is unused.

--- a/next/language/error_codes/E1007.md
+++ b/next/language/error_codes/E1007.md
@@ -1,0 +1,3 @@
+# E1007
+
+Field is never read.

--- a/next/language/error_codes/E1008.md
+++ b/next/language/error_codes/E1008.md
@@ -1,0 +1,3 @@
+# E1008
+
+The modifier is redundant here since field is modifier by default.

--- a/next/language/error_codes/E1009.md
+++ b/next/language/error_codes/E1009.md
@@ -1,0 +1,3 @@
+# E1009
+
+The struct is never constructed.

--- a/next/language/error_codes/E1010.md
+++ b/next/language/error_codes/E1010.md
@@ -1,0 +1,3 @@
+# E1010
+
+Unused pattern.

--- a/next/language/error_codes/E1011.md
+++ b/next/language/error_codes/E1011.md
@@ -1,0 +1,3 @@
+# E1011
+
+Partial match.

--- a/next/language/error_codes/E1012.md
+++ b/next/language/error_codes/E1012.md
@@ -1,0 +1,3 @@
+# E1012
+
+Unreachable code.

--- a/next/language/error_codes/E1013.md
+++ b/next/language/error_codes/E1013.md
@@ -1,0 +1,3 @@
+# E1013
+
+The type of this expression contains unresolved type variables.

--- a/next/language/error_codes/E1014.md
+++ b/next/language/error_codes/E1014.md
@@ -1,0 +1,3 @@
+# E1014
+
+Type name should be capitalized.

--- a/next/language/error_codes/E1015.md
+++ b/next/language/error_codes/E1015.md
@@ -1,0 +1,3 @@
+# E1015
+
+The mutability is never used.

--- a/next/language/error_codes/E1016.md
+++ b/next/language/error_codes/E1016.md
@@ -1,0 +1,3 @@
+# E1016
+
+Parser consistency check failed.

--- a/next/language/error_codes/E1018.md
+++ b/next/language/error_codes/E1018.md
@@ -1,0 +1,3 @@
+# E1018
+
+There is no [continue] in this loop expression, so [loop] is useless here.

--- a/next/language/error_codes/E1019.md
+++ b/next/language/error_codes/E1019.md
@@ -1,0 +1,3 @@
+# E1019
+
+Toplevel declaration is not left aligned.

--- a/next/language/error_codes/E1020.md
+++ b/next/language/error_codes/E1020.md
@@ -1,0 +1,3 @@
+# E1020
+
+Invalid pragma.

--- a/next/language/error_codes/E1021.md
+++ b/next/language/error_codes/E1021.md
@@ -1,0 +1,3 @@
+# E1021
+
+Some arguments of constructor are omitted in pattern.

--- a/next/language/error_codes/E1022.md
+++ b/next/language/error_codes/E1022.md
@@ -1,0 +1,3 @@
+# E1022
+
+Ambiguous block expression.

--- a/next/language/error_codes/E1023.md
+++ b/next/language/error_codes/E1023.md
@@ -1,0 +1,3 @@
+# E1023
+
+The body of this try expression never raises any error.

--- a/next/language/error_codes/E1024.md
+++ b/next/language/error_codes/E1024.md
@@ -1,0 +1,3 @@
+# E1024
+
+The error type of this function is never used.

--- a/next/language/error_codes/E1026.md
+++ b/next/language/error_codes/E1026.md
@@ -1,0 +1,3 @@
+# E1026
+
+The patterns are complete so the usage of `catch!` is useless.

--- a/next/language/error_codes/E1027.md
+++ b/next/language/error_codes/E1027.md
@@ -1,0 +1,3 @@
+# E1027
+
+The syntax is deprecated.

--- a/next/language/error_codes/E1028.md
+++ b/next/language/error_codes/E1028.md
@@ -1,0 +1,3 @@
+# E1028
+
+Unfinished code.

--- a/next/language/error_codes/E1029.md
+++ b/next/language/error_codes/E1029.md
@@ -1,0 +1,3 @@
+# E1029
+
+Unused package.

--- a/next/language/error_codes/E1030.md
+++ b/next/language/error_codes/E1030.md
@@ -1,0 +1,3 @@
+# E1030
+
+The package alias is empty.

--- a/next/language/error_codes/E1031.md
+++ b/next/language/error_codes/E1031.md
@@ -1,0 +1,3 @@
+# E1031
+
+The optional argument is never supplied.

--- a/next/language/error_codes/E1032.md
+++ b/next/language/error_codes/E1032.md
@@ -1,0 +1,3 @@
+# E1032
+
+Default value of optional argument is unused.

--- a/next/language/error_codes/E1033.md
+++ b/next/language/error_codes/E1033.md
@@ -1,0 +1,3 @@
+# E1033
+
+The import value is never used directly.

--- a/next/language/error_codes/E1034.md
+++ b/next/language/error_codes/E1034.md
@@ -1,0 +1,3 @@
+# E1034
+
+The syntax `~label` is deprecated.

--- a/next/language/error_codes/E1035.md
+++ b/next/language/error_codes/E1035.md
@@ -1,0 +1,3 @@
+# E1035
+
+The word is reserved for possible future use.

--- a/next/language/error_codes/E1036.md
+++ b/next/language/error_codes/E1036.md
@@ -1,0 +1,3 @@
+# E1036
+
+The label name shadows a label name that is already in scope.

--- a/next/language/error_codes/E1037.md
+++ b/next/language/error_codes/E1037.md
@@ -1,0 +1,3 @@
+# E1037
+
+The label name is never used.

--- a/next/language/error_codes/E1038.md
+++ b/next/language/error_codes/E1038.md
@@ -1,0 +1,3 @@
+# E1038
+
+Useless guard because the pattern is irrefutable.

--- a/next/language/error_codes/E1039.md
+++ b/next/language/error_codes/E1039.md
@@ -1,0 +1,3 @@
+# E1039
+
+Method name conflicts with another definition.

--- a/next/language/error_codes/E1040.md
+++ b/next/language/error_codes/E1040.md
@@ -1,0 +1,3 @@
+# E1040
+
+Calling this kind of method directly via name(..) is deprecated.

--- a/next/language/error_codes/E2000.md
+++ b/next/language/error_codes/E2000.md
@@ -1,0 +1,59 @@
+# E2000
+
+The usage of function (type, trait, etc.) is flagged with alert. Usually, alert
+message comes with a alert kind and a detailed description of the alert. If you
+are using the function from a library, these alerts are set by the library
+author to provide some more information on the usage of the function
+
+There are some common alerts that you may encounter:
+
+* `deprecated`: indicates the function (type, trait, etc) is deprecated and
+  should not be used or migrate to new APIs.
+* `unsafe`: indicates this API panics, breaks internal invariants, has undefined
+  behavior under some circumstances. The concrete semantics of this kind of
+  alerts may be different across packages, and please consult the documentation
+  or the author of these packages for further details.
+
+## Erroneous example
+
+```moonbit
+/// @alert deprecated "Use `greet` instead"
+fn greeting() -> String {
+  "Hello!"
+}
+
+fn greet(name~ : String = "") -> String {
+  if name != "" {
+    "Hello!"
+  } else {
+    "Hello, \{name}!"
+  }
+}
+
+fn main() -> Unit {
+  println(greeting())
+  //      ^~~~~~~~ Warning (Alert deprecated): Use `greet` instead(2000)
+}
+```
+
+## Suggestion
+
+One way to fix the alert, is to change your code as suggested by the message (like `deprecated`):
+
+```moonbit
+// ... code in the example above ...
+fn main() -> Unit {
+  println(greet(name="world"))
+}
+```
+
+If you clearly know what you are doing and would like to suppress the alert, you can change the `moon.pkg.json` file for packages where you would like to disable **this kind of alert**. For example:
+
+```moonbit
+{
+  // ... other fields in the file
+  "alert-list": "-deprecated"
+}
+```
+
+NOTE: There is no way to disable alerts for a line/file.

--- a/next/language/error_codes/E3001.md
+++ b/next/language/error_codes/E3001.md
@@ -1,0 +1,3 @@
+# E3001
+
+Lexing error

--- a/next/language/error_codes/E3002.md
+++ b/next/language/error_codes/E3002.md
@@ -1,0 +1,3 @@
+# E3002
+
+Parse error

--- a/next/language/error_codes/E3003.md
+++ b/next/language/error_codes/E3003.md
@@ -1,0 +1,21 @@
+# E3003
+
+`init` and `main` function must have no arguments and no return value.
+
+## Erroneous example
+
+```moonbit
+fn main() -> Unit {
+  println("Hello, world!")
+}
+```
+
+## Suggestion
+
+Remove the argument list and return type annotation, as:
+
+```moonbit
+fn main {
+  println("Hello, world!")
+}
+```

--- a/next/language/error_codes/E3004.md
+++ b/next/language/error_codes/E3004.md
@@ -1,0 +1,22 @@
+# E3004
+
+Missing parameters list. Add `()` after the name of the function if it takes 0
+parameter.
+
+## Erroneous example
+
+```moonbit
+fn greet {
+  println("Hello, world!")
+}
+```
+
+## Suggestion
+
+Add `()` after the function name.
+
+```moonbit
+fn greet() {
+  println("Hello, world!")
+}
+```

--- a/next/language/error_codes/E3005.md
+++ b/next/language/error_codes/E3005.md
@@ -1,0 +1,26 @@
+# E3005
+
+There is no such visibility for the entity (function/type/trait/...).
+
+Usually, this means that you put an `priv` visibility modifier on a entity is
+by-default private.
+
+See the [Access
+Control](https://docs.moonbitlang.com/en/latest/language/packages.html#access-control)
+section of [MoonBit Language
+Documentation](https://docs.moonbitlang.com/en/latest/language/index.html) for a
+detailed explanaion on the visibility in MoonBit.
+
+## Erroneous example
+
+```moonbit
+priv let value = 3
+```
+
+## Suggestion
+
+Remove the visibility modifier from the definition of the entity:
+
+```moonbit
+let value = 3 // This is already `priv` by default.
+```

--- a/next/language/error_codes/E3006.md
+++ b/next/language/error_codes/E3006.md
@@ -1,0 +1,25 @@
+# E3006
+
+There is no individual visibility control fro enum constructors.
+
+Usually, this means that you put an `priv` or `pub` visibility modifier on a enum constructor.
+
+## Erroneous example
+
+```moonbit
+enum A {
+  priv A1
+  pub A2
+}
+```
+
+## Suggestion
+
+Remove the visibility modifier from the definition of the enum constructor:
+
+```moonbit
+enum A {
+  A1
+  A2
+}
+```

--- a/next/language/error_codes/E3007.md
+++ b/next/language/error_codes/E3007.md
@@ -1,0 +1,15 @@
+# E3007
+
+Wrong location of `..` in pattern match. Put `..` at the end of the pattern.
+
+## Erroneous example
+
+```moonbit
+let {a, .., c} = s
+```
+
+## Suggestion
+
+```moonbit
+let {a, c, ..} = s
+```

--- a/next/language/error_codes/E3008.md
+++ b/next/language/error_codes/E3008.md
@@ -1,0 +1,17 @@
+# E3008
+
+There are multiple `..` patterns in array pattern. Remove until there is only one `..` pattern in array pattern.
+
+## Erroneous example
+
+```moonbit
+let [fst, .., .., snd] = array
+```
+
+## Suggestion
+
+Remove the extra `..` pattern.
+
+```moonbit
+let [fst, .., snd] = array
+```

--- a/next/language/error_codes/E3009.md
+++ b/next/language/error_codes/E3009.md
@@ -1,0 +1,46 @@
+# E3009
+
+Record pattern cannot contain only `..`, use wildcard pattern `_` instead.
+
+## Erroneous example
+
+```moonbit
+struct Point {
+  x: Int,
+  y: Int
+}
+
+fn process_point(p: Point) {
+  match p {
+    { .. } -> println("Got a point")
+  }
+}
+```
+
+## Suggestion
+
+Use the wildcard pattern `_` instead of `{ .. }`:
+
+```moonbit
+struct Point {
+  x: Int,
+  y: Int
+}
+
+fn process_point(p: Point) {
+  match p {
+    _ -> println("Got a point")
+  }
+}
+```
+
+You can also use `{ .. }` along with other fields if you want to match specific fields:
+
+```moonbit
+fn process_point(p: Point) {
+  match p {
+    { x: 0, .. } -> println("Point on y-axis")
+    _ -> println("Other point")
+  }
+}
+```

--- a/next/language/error_codes/E3010.md
+++ b/next/language/error_codes/E3010.md
@@ -1,0 +1,33 @@
+# E3010
+
+Only labelled arguments can have default value.
+
+## Erroneous example
+
+```moonbit
+fn greet(name = "World") {
+  println("Hello, " + name + "!")
+}
+```
+
+## Suggestion
+
+Use a labelled argument with `~` if you want to provide a default value:
+
+```moonbit
+fn greet(~name = "World") {
+  println("Hello, " + name + "!")
+}
+
+// Can be called as:
+greet() // Uses default value "World"
+greet(~name = "Alice") // Uses provided value "Alice"
+```
+
+Or remove the default value if you want to keep it as a positional argument:
+
+```moonbit
+fn greet(name: String) {
+  println("Hello, " + name + "!")
+}
+```

--- a/next/language/error_codes/E3011.md
+++ b/next/language/error_codes/E3011.md
@@ -1,0 +1,3 @@
+# E3011
+
+Invalid left value for assignment.

--- a/next/language/error_codes/E3012.md
+++ b/next/language/error_codes/E3012.md
@@ -1,0 +1,3 @@
+# E3012
+
+Record pattern and map pattern cannot be mixed.

--- a/next/language/error_codes/E3013.md
+++ b/next/language/error_codes/E3013.md
@@ -1,0 +1,3 @@
+# E3013
+
+Map patterns are always open, the `..` is useless.

--- a/next/language/error_codes/E3014.md
+++ b/next/language/error_codes/E3014.md
@@ -1,0 +1,3 @@
+# E3014
+
+Inline wasm syntax error.

--- a/next/language/error_codes/E3015.md
+++ b/next/language/error_codes/E3015.md
@@ -1,0 +1,3 @@
+# E3015
+
+The parameter already has default value `None`.

--- a/next/language/error_codes/E3016.md
+++ b/next/language/error_codes/E3016.md
@@ -1,0 +1,3 @@
+# E3016
+
+Unexpected `~` in argument. Did you mean `label=pattern` or `label~`?

--- a/next/language/error_codes/E3017.md
+++ b/next/language/error_codes/E3017.md
@@ -1,0 +1,3 @@
+# E3017
+
+JSON parse error.

--- a/next/language/error_codes/E3018.md
+++ b/next/language/error_codes/E3018.md
@@ -1,0 +1,3 @@
+# E3018
+
+Bounds of range pattern must be constant, named constant or wildcard.

--- a/next/language/error_codes/E3019.md
+++ b/next/language/error_codes/E3019.md
@@ -1,0 +1,3 @@
+# E3019
+
+Inclusive range pattern `a..=b` cannot have `_` as upper bound.

--- a/next/language/error_codes/E3020.md
+++ b/next/language/error_codes/E3020.md
@@ -1,0 +1,3 @@
+# E3020
+
+Unexpected `=` in struct expression. The correct syntax for struct expression is `{ field: expression }`.

--- a/next/language/error_codes/E3800.md
+++ b/next/language/error_codes/E3800.md
@@ -1,0 +1,3 @@
+# E3800
+
+Expecting a newline or `;` here, but encountered another delimiter.

--- a/next/language/error_codes/E4000.md
+++ b/next/language/error_codes/E4000.md
@@ -1,0 +1,41 @@
+# E4000
+
+Generic type variable name is already used.
+
+## Erroneous example
+
+```moonbit
+struct Container[T, T] {
+  value : T
+}
+
+fn transform[A, A](x : A) -> A {
+  x
+}
+```
+
+## Suggestion
+
+Use different names for type variables:
+
+```moonbit
+struct Container[T1, T2] {
+  value : T1
+}
+
+fn transform[A, B](x : A) -> B {
+  // ... implementation
+}
+```
+
+Or remove the duplicate type parameter if you meant to use the same type:
+
+```moonbit
+struct Container[T] {
+  value : T
+}
+
+fn transform[A](x : A) -> A {
+  x
+}
+```

--- a/next/language/error_codes/E4001.md
+++ b/next/language/error_codes/E4001.md
@@ -1,0 +1,3 @@
+# E4001
+
+A field with different visibility cannot be declared within a struct.

--- a/next/language/error_codes/E4002.md
+++ b/next/language/error_codes/E4002.md
@@ -1,0 +1,3 @@
+# E4002
+
+The modifier is not supported here.

--- a/next/language/error_codes/E4003.md
+++ b/next/language/error_codes/E4003.md
@@ -1,0 +1,3 @@
+# E4003
+
+This is a reserved type name. Cannot declare it as a type variable, type, or trait.

--- a/next/language/error_codes/E4004.md
+++ b/next/language/error_codes/E4004.md
@@ -1,0 +1,3 @@
+# E4004
+
+Trait methods cannot have type parameters (be polymorphic). MoonBit currently does not support generic/polymorphic methods within trait definitions.

--- a/next/language/error_codes/E4005.md
+++ b/next/language/error_codes/E4005.md
@@ -1,0 +1,31 @@
+# E4005
+
+This error occurs when a trait has multiple declarations of the same method name. Each method in a trait must have a unique name to avoid ambiguity.
+
+## Erroneous example
+
+```moonbit
+trait Animal {
+  make_sound(Self) -> String
+  make_sound(Self) -> String  // Error: method make_sound is declared twice
+}
+```
+
+## Suggestion
+
+Remove the duplicate method declaration and keep only one definition for each method name:
+
+```moonbit
+trait Animal {
+  make_sound(Self) -> String  // Only declare the method once
+}
+```
+
+If you need different method behaviors, use distinct method names:
+
+```moonbit
+trait Animal {
+  make_sound(Self) -> String
+  make_loud_sound(Self) -> String  // Use a different name for different behavior
+}
+```

--- a/next/language/error_codes/E4006.md
+++ b/next/language/error_codes/E4006.md
@@ -1,0 +1,40 @@
+# E4006
+
+This error occurs when the same local function name is declared multiple times within the same scope. Each local function name must be unique within its scope.
+
+## Erroneous Example
+
+```moonbit
+fn main {
+  fn helper() {
+    1 + 1
+  }
+
+  fn helper() { // E4006: local function 'helper' is already defined
+    2 + 2
+  }
+
+  helper()
+}
+```
+
+## Suggestion
+
+To fix this error, give each local function a unique name:
+
+```moonbit
+fn main {
+  fn helper1() {
+    1 + 1
+  }
+
+  fn helper2() {
+    2 + 2
+  }
+
+  helper1()
+  helper2()
+}
+```
+
+You can also move one of the functions to a different scope or merge the functionality into a single function if they serve similar purposes.

--- a/next/language/error_codes/E4007.md
+++ b/next/language/error_codes/E4007.md
@@ -1,0 +1,32 @@
+# E4007
+
+Constructor arguments cannot be unit `()`. MoonBit does not allow constructors to take unit as an argument because it would be redundant - a constructor without arguments already represents a singleton value.
+
+## Erroneous example
+
+```moonbit
+enum Status {
+  Done()  // Error: constructor can't take unit as argument
+  Pending
+}
+```
+
+## Suggestion
+
+Remove the unit argument from the constructor since it adds no value:
+
+```moonbit
+enum Status {
+  Done    // Correct: constructor without arguments
+  Pending
+}
+```
+
+If you need the constructor to take arguments, provide meaningful values instead of unit:
+
+```moonbit
+enum Status {
+  Done(Int) // Constructor with meaningful argument
+  Pending
+}
+```

--- a/next/language/error_codes/E4008.md
+++ b/next/language/error_codes/E4008.md
@@ -1,0 +1,3 @@
+# E4008
+
+FFI function cannot have type parameters.

--- a/next/language/error_codes/E4009.md
+++ b/next/language/error_codes/E4009.md
@@ -1,0 +1,3 @@
+# E4009
+
+Match function expects a different number of arguments than provided.

--- a/next/language/error_codes/E4010.md
+++ b/next/language/error_codes/E4010.md
@@ -1,0 +1,3 @@
+# E4010
+
+`pub` is not allowed on default implementation for traits.

--- a/next/language/error_codes/E4011.md
+++ b/next/language/error_codes/E4011.md
@@ -1,0 +1,3 @@
+# E4011
+
+Type parameters are not allowed on default implementation for traits.

--- a/next/language/error_codes/E4012.md
+++ b/next/language/error_codes/E4012.md
@@ -1,0 +1,3 @@
+# E4012
+
+Mutable constructor fields are only allowed on labelled arguments.

--- a/next/language/error_codes/E4013.md
+++ b/next/language/error_codes/E4013.md
@@ -1,0 +1,3 @@
+# E4013
+
+This function has a type which expects a different number of arguments than provided.

--- a/next/language/error_codes/E4014.md
+++ b/next/language/error_codes/E4014.md
@@ -1,0 +1,3 @@
+# E4014
+
+Type Mismatch.

--- a/next/language/error_codes/E4015.md
+++ b/next/language/error_codes/E4015.md
@@ -1,0 +1,3 @@
+# E4015
+
+Type has no method with the specified name.

--- a/next/language/error_codes/E4016.md
+++ b/next/language/error_codes/E4016.md
@@ -1,0 +1,3 @@
+# E4016
+
+Please implement the required method for the type to use the infix operator.

--- a/next/language/error_codes/E4017.md
+++ b/next/language/error_codes/E4017.md
@@ -1,0 +1,3 @@
+# E4017
+
+Method of type is ambiguous, it may come from multiple traits.

--- a/next/language/error_codes/E4018.md
+++ b/next/language/error_codes/E4018.md
@@ -1,0 +1,3 @@
+# E4018
+
+Cannot resolve trait for the given type.

--- a/next/language/error_codes/E4019.md
+++ b/next/language/error_codes/E4019.md
@@ -1,0 +1,3 @@
+# E4019
+
+The label is declared twice in this function.

--- a/next/language/error_codes/E4020.md
+++ b/next/language/error_codes/E4020.md
@@ -1,0 +1,3 @@
+# E4020
+
+Package not found in the loaded packages.

--- a/next/language/error_codes/E4021.md
+++ b/next/language/error_codes/E4021.md
@@ -1,0 +1,3 @@
+# E4021
+
+The value identifier is unbound.

--- a/next/language/error_codes/E4023.md
+++ b/next/language/error_codes/E4023.md
@@ -1,0 +1,3 @@
+# E4023
+
+The trait is not found.

--- a/next/language/error_codes/E4024.md
+++ b/next/language/error_codes/E4024.md
@@ -1,0 +1,3 @@
+# E4024
+
+The type/trait is not found.

--- a/next/language/error_codes/E4025.md
+++ b/next/language/error_codes/E4025.md
@@ -1,0 +1,3 @@
+# E4025
+
+Method has been defined for multiple types.

--- a/next/language/error_codes/E4026.md
+++ b/next/language/error_codes/E4026.md
@@ -1,0 +1,3 @@
+# E4026
+
+The field is not found.

--- a/next/language/error_codes/E4027.md
+++ b/next/language/error_codes/E4027.md
@@ -1,0 +1,3 @@
+# E4027
+
+Unused type parameter.

--- a/next/language/error_codes/E4028.md
+++ b/next/language/error_codes/E4028.md
@@ -1,0 +1,3 @@
+# E4028
+
+This expression has a type which is not a record.

--- a/next/language/error_codes/E4029.md
+++ b/next/language/error_codes/E4029.md
@@ -1,0 +1,3 @@
+# E4029
+
+This expression has a type which is not a variant.

--- a/next/language/error_codes/E4030.md
+++ b/next/language/error_codes/E4030.md
@@ -1,0 +1,3 @@
+# E4030
+
+The record type does not have the specified field.

--- a/next/language/error_codes/E4031.md
+++ b/next/language/error_codes/E4031.md
@@ -1,0 +1,3 @@
+# E4031
+
+The constructor is not found.

--- a/next/language/error_codes/E4032.md
+++ b/next/language/error_codes/E4032.md
@@ -1,0 +1,3 @@
+# E4032
+
+The type is undefined.

--- a/next/language/error_codes/E4033.md
+++ b/next/language/error_codes/E4033.md
@@ -1,0 +1,3 @@
+# E4033
+
+There is no record definition with the specified fields.

--- a/next/language/error_codes/E4034.md
+++ b/next/language/error_codes/E4034.md
@@ -1,0 +1,3 @@
+# E4034
+
+Multiple possible record types detected, please add more annotation.

--- a/next/language/error_codes/E4036.md
+++ b/next/language/error_codes/E4036.md
@@ -1,0 +1,3 @@
+# E4036
+
+Cannot create values of the read-only type.

--- a/next/language/error_codes/E4037.md
+++ b/next/language/error_codes/E4037.md
@@ -1,0 +1,3 @@
+# E4037
+
+Cannot perform action: package is not imported.

--- a/next/language/error_codes/E4038.md
+++ b/next/language/error_codes/E4038.md
@@ -1,0 +1,3 @@
+# E4038
+
+Trait object for the type is not allowed.

--- a/next/language/error_codes/E4039.md
+++ b/next/language/error_codes/E4039.md
@@ -1,0 +1,3 @@
+# E4039
+
+There is no method with the specified name in this trait.

--- a/next/language/error_codes/E4040.md
+++ b/next/language/error_codes/E4040.md
@@ -1,0 +1,3 @@
+# E4040
+
+The type constructor expects a different number of arguments than provided.

--- a/next/language/error_codes/E4041.md
+++ b/next/language/error_codes/E4041.md
@@ -1,0 +1,3 @@
+# E4041
+
+Partial type is not allowed in toplevel declarations.

--- a/next/language/error_codes/E4042.md
+++ b/next/language/error_codes/E4042.md
@@ -1,0 +1,3 @@
+# E4042
+
+Invalid stub type.

--- a/next/language/error_codes/E4043.md
+++ b/next/language/error_codes/E4043.md
@@ -1,0 +1,3 @@
+# E4043
+
+The record field is defined or matched multiple times.

--- a/next/language/error_codes/E4044.md
+++ b/next/language/error_codes/E4044.md
@@ -1,0 +1,3 @@
+# E4044
+
+Record fields are missing. Use `..` to ignore them in patterns.

--- a/next/language/error_codes/E4045.md
+++ b/next/language/error_codes/E4045.md
@@ -1,0 +1,3 @@
+# E4045
+
+The field is not defined in the record type.

--- a/next/language/error_codes/E4046.md
+++ b/next/language/error_codes/E4046.md
@@ -1,0 +1,3 @@
+# E4046
+
+A public definition cannot depend on private entities.

--- a/next/language/error_codes/E4047.md
+++ b/next/language/error_codes/E4047.md
@@ -1,0 +1,3 @@
+# E4047
+
+Package not found when loading packages.

--- a/next/language/error_codes/E4048.md
+++ b/next/language/error_codes/E4048.md
@@ -1,0 +1,3 @@
+# E4048
+
+The package file is in wrong format.

--- a/next/language/error_codes/E4049.md
+++ b/next/language/error_codes/E4049.md
@@ -1,0 +1,3 @@
+# E4049
+
+Magic number mismatch for the package file.

--- a/next/language/error_codes/E4050.md
+++ b/next/language/error_codes/E4050.md
@@ -1,0 +1,3 @@
+# E4050
+
+Definition cycle detected in dependencies.

--- a/next/language/error_codes/E4051.md
+++ b/next/language/error_codes/E4051.md
@@ -1,0 +1,3 @@
+# E4051
+
+The identifier is declared twice.

--- a/next/language/error_codes/E4052.md
+++ b/next/language/error_codes/E4052.md
@@ -1,0 +1,3 @@
+# E4052
+
+The type/trait name duplicates with a previously defined identifier.

--- a/next/language/error_codes/E4053.md
+++ b/next/language/error_codes/E4053.md
@@ -1,0 +1,3 @@
+# E4053
+
+Invalid type for "self": must be a type constructor.

--- a/next/language/error_codes/E4054.md
+++ b/next/language/error_codes/E4054.md
@@ -1,0 +1,3 @@
+# E4054
+
+Cannot determine self type of extension method. [Self] does not occur in the signature of the method

--- a/next/language/error_codes/E4055.md
+++ b/next/language/error_codes/E4055.md
@@ -1,0 +1,3 @@
+# E4055
+
+field is already declared.

--- a/next/language/error_codes/E4056.md
+++ b/next/language/error_codes/E4056.md
@@ -1,0 +1,3 @@
+# E4056
+
+The method has been defined.

--- a/next/language/error_codes/E4057.md
+++ b/next/language/error_codes/E4057.md
@@ -1,0 +1,3 @@
+# E4057
+
+The constructor is duplicate.

--- a/next/language/error_codes/E4059.md
+++ b/next/language/error_codes/E4059.md
@@ -1,0 +1,3 @@
+# E4059
+
+Cannot define method for foreign type.

--- a/next/language/error_codes/E4060.md
+++ b/next/language/error_codes/E4060.md
@@ -1,0 +1,3 @@
+# E4060
+
+Method type mismatch.

--- a/next/language/error_codes/E4061.md
+++ b/next/language/error_codes/E4061.md
@@ -1,0 +1,3 @@
+# E4061
+
+Cannot define method of foreign trait for foreign type.

--- a/next/language/error_codes/E4062.md
+++ b/next/language/error_codes/E4062.md
@@ -1,0 +1,3 @@
+# E4062
+
+This `impl` shadows method previously defined. This will result in different implementations for trait inside and outside current package.

--- a/next/language/error_codes/E4063.md
+++ b/next/language/error_codes/E4063.md
@@ -1,0 +1,3 @@
+# E4063
+
+Type does not implement trait, although an `impl` is defined.

--- a/next/language/error_codes/E4065.md
+++ b/next/language/error_codes/E4065.md
@@ -1,0 +1,3 @@
+# E4065
+
+Overloaded operator should accept the correct number of arguments.

--- a/next/language/error_codes/E4066.md
+++ b/next/language/error_codes/E4066.md
@@ -1,0 +1,3 @@
+# E4066
+
+Overloaded operator has inconsistent parameter type.

--- a/next/language/error_codes/E4067.md
+++ b/next/language/error_codes/E4067.md
@@ -1,0 +1,3 @@
+# E4067
+
+Missing main function in the main package.

--- a/next/language/error_codes/E4068.md
+++ b/next/language/error_codes/E4068.md
@@ -1,0 +1,3 @@
+# E4068
+
+Main function is already defined.

--- a/next/language/error_codes/E4069.md
+++ b/next/language/error_codes/E4069.md
@@ -1,0 +1,3 @@
+# E4069
+
+Unexpected main function in the non-main package.

--- a/next/language/error_codes/E4070.md
+++ b/next/language/error_codes/E4070.md
@@ -1,0 +1,3 @@
+# E4070
+
+Unknown intrinsic.

--- a/next/language/error_codes/E4071.md
+++ b/next/language/error_codes/E4071.md
@@ -1,0 +1,3 @@
+# E4071
+
+Multiple intrinsic is not supported.

--- a/next/language/error_codes/E4072.md
+++ b/next/language/error_codes/E4072.md
@@ -1,0 +1,3 @@
+# E4072
+
+Method of trait already has a default implementation.

--- a/next/language/error_codes/E4073.md
+++ b/next/language/error_codes/E4073.md
@@ -1,0 +1,3 @@
+# E4073
+
+Cannot provide default implementation for foreign trait.

--- a/next/language/error_codes/E4074.md
+++ b/next/language/error_codes/E4074.md
@@ -1,0 +1,3 @@
+# E4074
+
+Cannot infer the type of variable, please add more type annotation.

--- a/next/language/error_codes/E4075.md
+++ b/next/language/error_codes/E4075.md
@@ -1,0 +1,3 @@
+# E4075
+
+Missing type annotation for the parameter.

--- a/next/language/error_codes/E4076.md
+++ b/next/language/error_codes/E4076.md
@@ -1,0 +1,3 @@
+# E4076
+
+Missing type annotation for the return value.

--- a/next/language/error_codes/E4077.md
+++ b/next/language/error_codes/E4077.md
@@ -1,0 +1,3 @@
+# E4077
+
+Don't know how to derive trait for type.

--- a/next/language/error_codes/E4078.md
+++ b/next/language/error_codes/E4078.md
@@ -1,0 +1,3 @@
+# E4078
+
+Cannot derive trait for type.

--- a/next/language/error_codes/E4079.md
+++ b/next/language/error_codes/E4079.md
@@ -1,0 +1,3 @@
+# E4079
+
+Cannot derive trait: method is already defined.

--- a/next/language/error_codes/E4080.md
+++ b/next/language/error_codes/E4080.md
@@ -1,0 +1,3 @@
+# E4080
+
+Arity mismatch: incorrect number of arguments provided.

--- a/next/language/error_codes/E4081.md
+++ b/next/language/error_codes/E4081.md
@@ -1,0 +1,3 @@
+# E4081
+
+The identifier is bound more than once in the same pattern.

--- a/next/language/error_codes/E4082.md
+++ b/next/language/error_codes/E4082.md
@@ -1,0 +1,3 @@
+# E4082
+
+Variable is not bound in all patterns.

--- a/next/language/error_codes/E4083.md
+++ b/next/language/error_codes/E4083.md
@@ -1,0 +1,3 @@
+# E4083
+
+The type does not implement `op_as_view` method.

--- a/next/language/error_codes/E4084.md
+++ b/next/language/error_codes/E4084.md
@@ -1,0 +1,3 @@
+# E4084
+
+The label is supplied twice.

--- a/next/language/error_codes/E4085.md
+++ b/next/language/error_codes/E4085.md
@@ -1,0 +1,3 @@
+# E4085
+
+This has no parameter with the given label.

--- a/next/language/error_codes/E4086.md
+++ b/next/language/error_codes/E4086.md
@@ -1,0 +1,3 @@
+# E4086
+
+The labels are required by this function, but not supplied.

--- a/next/language/error_codes/E4087.md
+++ b/next/language/error_codes/E4087.md
@@ -1,0 +1,3 @@
+# E4087
+
+The variable is not mutable.

--- a/next/language/error_codes/E4088.md
+++ b/next/language/error_codes/E4088.md
@@ -1,0 +1,3 @@
+# E4088
+
+The record field is immutable.

--- a/next/language/error_codes/E4089.md
+++ b/next/language/error_codes/E4089.md
@@ -1,0 +1,3 @@
+# E4089
+
+Tuple has no field with the given index.

--- a/next/language/error_codes/E4090.md
+++ b/next/language/error_codes/E4090.md
@@ -1,0 +1,3 @@
+# E4090
+
+Tuples are not mutable.

--- a/next/language/error_codes/E4091.md
+++ b/next/language/error_codes/E4091.md
@@ -1,0 +1,3 @@
+# E4091
+
+The type has no field with the given name.

--- a/next/language/error_codes/E4092.md
+++ b/next/language/error_codes/E4092.md
@@ -1,0 +1,3 @@
+# E4092
+
+Missing annotation for this empty record.

--- a/next/language/error_codes/E4093.md
+++ b/next/language/error_codes/E4093.md
@@ -1,0 +1,3 @@
+# E4093
+
+The type is not a record type.

--- a/next/language/error_codes/E4094.md
+++ b/next/language/error_codes/E4094.md
@@ -1,0 +1,3 @@
+# E4094
+
+Cannot modify a read-only field.

--- a/next/language/error_codes/E4095.md
+++ b/next/language/error_codes/E4095.md
@@ -1,0 +1,3 @@
+# E4095
+
+Integer literal is out of range.

--- a/next/language/error_codes/E4100.md
+++ b/next/language/error_codes/E4100.md
@@ -1,0 +1,3 @@
+# E4100
+
+The type is not a trait.

--- a/next/language/error_codes/E4101.md
+++ b/next/language/error_codes/E4101.md
@@ -1,0 +1,3 @@
+# E4101
+
+Unsupported expression after the pipe operator.

--- a/next/language/error_codes/E4102.md
+++ b/next/language/error_codes/E4102.md
@@ -1,0 +1,3 @@
+# E4102
+
+Outside of a loop.

--- a/next/language/error_codes/E4103.md
+++ b/next/language/error_codes/E4103.md
@@ -1,0 +1,3 @@
+# E4103
+
+This loop has incorrect number of patterns supplied.

--- a/next/language/error_codes/E4104.md
+++ b/next/language/error_codes/E4104.md
@@ -1,0 +1,3 @@
+# E4104
+
+Current loop expects different number of arguments than supplied with `continue`.

--- a/next/language/error_codes/E4105.md
+++ b/next/language/error_codes/E4105.md
@@ -1,0 +1,3 @@
+# E4105
+
+Current loop has result type mismatch with `break` argument.

--- a/next/language/error_codes/E4106.md
+++ b/next/language/error_codes/E4106.md
@@ -1,0 +1,3 @@
+# E4106
+
+Unknown binder in the for-loop steps. Binders in the steps must be declared in the initialization block of the for-loop.

--- a/next/language/error_codes/E4107.md
+++ b/next/language/error_codes/E4107.md
@@ -1,0 +1,3 @@
+# E4107
+
+Name is declared multiple times in this for-loop.

--- a/next/language/error_codes/E4108.md
+++ b/next/language/error_codes/E4108.md
@@ -1,0 +1,3 @@
+# E4108
+
+The loop is expected to yield a value, please add an `else` branch.

--- a/next/language/error_codes/E4109.md
+++ b/next/language/error_codes/E4109.md
@@ -1,0 +1,3 @@
+# E4109
+
+Return must be inside a function.

--- a/next/language/error_codes/E4110.md
+++ b/next/language/error_codes/E4110.md
@@ -1,0 +1,3 @@
+# E4110
+
+The loop is not expected to yield a value, please remove the argument of the `break` or add an `else` branch.

--- a/next/language/error_codes/E4111.md
+++ b/next/language/error_codes/E4111.md
@@ -1,0 +1,3 @@
+# E4111
+
+The usage of break statement is invalid.

--- a/next/language/error_codes/E4112.md
+++ b/next/language/error_codes/E4112.md
@@ -1,0 +1,3 @@
+# E4112
+
+The usage of continue statement is invalid.

--- a/next/language/error_codes/E4113.md
+++ b/next/language/error_codes/E4113.md
@@ -1,0 +1,3 @@
+# E4113
+
+Constructor has no field with the given name.

--- a/next/language/error_codes/E4114.md
+++ b/next/language/error_codes/E4114.md
@@ -1,0 +1,3 @@
+# E4114
+
+Only toplevel functions can have labelled arguments.

--- a/next/language/error_codes/E4115.md
+++ b/next/language/error_codes/E4115.md
@@ -1,0 +1,3 @@
+# E4115
+
+Cannot auto-fill parameter of this type.

--- a/next/language/error_codes/E4116.md
+++ b/next/language/error_codes/E4116.md
@@ -1,0 +1,3 @@
+# E4116
+
+Found hole _.

--- a/next/language/error_codes/E4117.md
+++ b/next/language/error_codes/E4117.md
@@ -1,0 +1,3 @@
+# E4117
+
+Function with labelled arguments can only be applied directly.

--- a/next/language/error_codes/E4118.md
+++ b/next/language/error_codes/E4118.md
@@ -1,0 +1,3 @@
+# E4118
+
+Cannot match type with map pattern.

--- a/next/language/error_codes/E4119.md
+++ b/next/language/error_codes/E4119.md
@@ -1,0 +1,3 @@
+# E4119
+
+This function is not a toplevel function, so it cannot have labelled arguments.

--- a/next/language/error_codes/E4120.md
+++ b/next/language/error_codes/E4120.md
@@ -1,0 +1,3 @@
+# E4120
+
+The application might raise errors, but it's not handled. Try adding an infix operator `!` or `?` to the application.

--- a/next/language/error_codes/E4121.md
+++ b/next/language/error_codes/E4121.md
@@ -1,0 +1,3 @@
+# E4121
+
+The attribute cannot be used on this application.

--- a/next/language/error_codes/E4122.md
+++ b/next/language/error_codes/E4122.md
@@ -1,0 +1,3 @@
+# E4122
+
+Invalid raise operation. Can only be used inside a function with error types in its signature.

--- a/next/language/error_codes/E4124.md
+++ b/next/language/error_codes/E4124.md
@@ -1,0 +1,3 @@
+# E4124
+
+The constructor is ambiguous: it may come from multiple types.

--- a/next/language/error_codes/E4125.md
+++ b/next/language/error_codes/E4125.md
@@ -1,0 +1,3 @@
+# E4125
+
+`?` operator cannot be used with `..`.

--- a/next/language/error_codes/E4127.md
+++ b/next/language/error_codes/E4127.md
@@ -1,0 +1,3 @@
+# E4127
+
+Type is not an error type.

--- a/next/language/error_codes/E4128.md
+++ b/next/language/error_codes/E4128.md
@@ -1,0 +1,3 @@
+# E4128
+
+Target of type alias must not be a type parameter.

--- a/next/language/error_codes/E4129.md
+++ b/next/language/error_codes/E4129.md
@@ -1,0 +1,3 @@
+# E4129
+
+Found cycle in type alias.

--- a/next/language/error_codes/E4130.md
+++ b/next/language/error_codes/E4130.md
@@ -1,0 +1,3 @@
+# E4130
+
+`derive` is not allowed for type alias.

--- a/next/language/error_codes/E4131.md
+++ b/next/language/error_codes/E4131.md
@@ -1,0 +1,3 @@
+# E4131
+
+The type alias is a function type, not a type constructor.

--- a/next/language/error_codes/E4132.md
+++ b/next/language/error_codes/E4132.md
@@ -1,0 +1,3 @@
+# E4132
+
+Invalid test parameter. Only one parameter with type `@test.T` is allowed.

--- a/next/language/error_codes/E4133.md
+++ b/next/language/error_codes/E4133.md
@@ -1,0 +1,3 @@
+# E4133
+
+This `for .. in` loop has incorrect number of loop variables.

--- a/next/language/error_codes/E4134.md
+++ b/next/language/error_codes/E4134.md
@@ -1,0 +1,3 @@
+# E4134
+
+The return type of this anonymous function is expected to include an error type. Please add the error type to the return type annotation or use `fn!` instead.

--- a/next/language/error_codes/E4135.md
+++ b/next/language/error_codes/E4135.md
@@ -1,0 +1,3 @@
+# E4135
+
+Inconsistent `impl` of trait: implementations have different constraints.

--- a/next/language/error_codes/E4136.md
+++ b/next/language/error_codes/E4136.md
@@ -1,0 +1,3 @@
+# E4136
+
+This expression has type that is not a newtype.

--- a/next/language/error_codes/E4137.md
+++ b/next/language/error_codes/E4137.md
@@ -1,0 +1,3 @@
+# E4137
+
+Range operators are currently only supported in `for .. in` loops.

--- a/next/language/error_codes/E4138.md
+++ b/next/language/error_codes/E4138.md
@@ -1,0 +1,3 @@
+# E4138
+
+Range operators only support builtin integer types, they cannot be used on this type.

--- a/next/language/error_codes/E4139.md
+++ b/next/language/error_codes/E4139.md
@@ -1,0 +1,3 @@
+# E4139
+
+This expression has type that cannot be implicitly ignored. Use `ignore(...)` or `let _ = ...` to explicitly ignore it.

--- a/next/language/error_codes/E4140.md
+++ b/next/language/error_codes/E4140.md
@@ -1,0 +1,3 @@
+# E4140
+
+Invalid C function name in extern "C" declaration.

--- a/next/language/error_codes/E4141.md
+++ b/next/language/error_codes/E4141.md
@@ -1,0 +1,3 @@
+# E4141
+
+This form of application is invalid for this argument, because it is not declared with the correct label.

--- a/next/language/error_codes/E4142.md
+++ b/next/language/error_codes/E4142.md
@@ -1,0 +1,3 @@
+# E4142
+
+This 'const' declaration is not constant.

--- a/next/language/error_codes/E4143.md
+++ b/next/language/error_codes/E4143.md
@@ -1,0 +1,3 @@
+# E4143
+
+Not a valid constant type, only immutable primitive types are allowed.

--- a/next/language/error_codes/E4144.md
+++ b/next/language/error_codes/E4144.md
@@ -1,0 +1,3 @@
+# E4144
+
+This is a constant, not a constructor, it cannot be applied to arguments.

--- a/next/language/error_codes/E4145.md
+++ b/next/language/error_codes/E4145.md
@@ -1,0 +1,3 @@
+# E4145
+
+Cannot implement trait because it is sealed.

--- a/next/language/error_codes/E4146.md
+++ b/next/language/error_codes/E4146.md
@@ -1,0 +1,3 @@
+# E4146
+
+Type is not supported by range pattern.

--- a/next/language/error_codes/E4147.md
+++ b/next/language/error_codes/E4147.md
@@ -1,0 +1,3 @@
+# E4147
+
+Range pattern bounds must satisfy the ordering constraint.

--- a/next/language/error_codes/E4148.md
+++ b/next/language/error_codes/E4148.md
@@ -1,0 +1,3 @@
+# E4148
+
+The label is undeclared.

--- a/next/language/error_codes/E4149.md
+++ b/next/language/error_codes/E4149.md
@@ -1,0 +1,3 @@
+# E4149
+
+Cannot call async function in this context.

--- a/next/language/error_codes/E4150.md
+++ b/next/language/error_codes/E4150.md
@@ -1,0 +1,3 @@
+# E4150
+
+Async function call attribute mismatch.

--- a/next/language/error_codes/index.md
+++ b/next/language/error_codes/index.md
@@ -1,0 +1,10 @@
+# Error Codes Index
+
+This page lists all error codes produced by the MoonBit compiler.
+
+```{toctree}
+:titlesonly:
+:glob:
+E*
+W*
+```

--- a/next/language/error_codes/index.md
+++ b/next/language/error_codes/index.md
@@ -6,5 +6,4 @@ This page lists all error codes produced by the MoonBit compiler.
 :titlesonly:
 :glob:
 E*
-W*
 ```

--- a/next/language/index.md
+++ b/next/language/index.md
@@ -31,4 +31,5 @@ docs
 ffi-and-wasm-host
 derive
 async-experimental
+error_codes/index
 ```


### PR DESCRIPTION
This PR add error codes index to the language documentation.

Most of the error code documentation is left mostly empty, they only contains the error message and should be expanded into a fully fledged, detailed error code documentation.