### PR TITLE
chore: add autocorrect to CI

### DIFF
--- a/.autocorrectrc
+++ b/.autocorrectrc
@@ -1,4 +1,5 @@
 # yaml-language-server: $schema=https://huacnlee.github.io/autocorrect/schema.json
 rules:
   # Default rules: https://github.com/huacnlee/autocorrect/raw/main/autocorrect/.autocorrectrc.default
+  space-backticks: 0
   halfwidth-punctuation: 0

--- a/.autocorrectrc
+++ b/.autocorrectrc
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://huacnlee.github.io/autocorrect/schema.json
+rules:
+  # Default rules: https://github.com/huacnlee/autocorrect/raw/main/autocorrect/.autocorrectrc.default
+  halfwidth-punctuation: 0

--- a/.github/workflows/typo.yml
+++ b/.github/workflows/typo.yml
@@ -15,4 +15,8 @@ jobs:
 
       - name: check typos
         uses: crate-ci/typos@v1.26.0
-  
+
+      - name: autocorrect lint
+        uses: huacnlee/autocorrect-action@v2
+        with:
+          args: . --lint --no-diff-bg-color


### PR DESCRIPTION
This PR is to integrate [AutoCorrect](https://github.com/huacnlee/autocorrect) with the CI.

> AutoCorrect is a powerful tool to help you to improve copywriting, correct spaces, words, and punctuations between CJK. 

The AutoCorrect now checks out hundreds of issues, see [the CI run result](https://github.com/liuly0322/moonbit-docs/actions/runs/13610011704/job/38045911699).

I can make a separate PR to confirm and fix these typos, maybe after https://github.com/moonbitlang/moonbit-docs/pull/543 is merged.