### PR TITLE
Update the docs about stub-cc* flags and `tcc -run`

### DIFF
--- a/next/toolchain/moon/commands.md
+++ b/next/toolchain/moon/commands.md
@@ -237,7 +237,10 @@ Test the current package
 * `--doc` — Run doc test
 * `--md` — Run test in markdown file
 
-
+If the target is `native`, the `--release` option is not used, and no `stub-cc*`
+options are specified in `moon.pkg.json` for any dependencies,
+the fast-debugging-test feature will be enabled.
+It will attempt to use `tcc -run` to execute the tests.
 
 ## `moon clean`
 

--- a/next/toolchain/moon/package.md
+++ b/next/toolchain/moon/package.md
@@ -257,7 +257,6 @@ The `link` option is used to specify link options, and its value can be either a
 
 - The `cc` option is used to specify the compiler for compiling the `moonc`-generated C source files.
   It can be either a full path to the compiler or a simple name that is accessible via the PATH environment variable.
-  By default, the 
 
   ```json
   {


### PR DESCRIPTION
This text describes the latest backend link options and includes a brief description of the fast-debugging-test feature.