### PR TITLE
docs: fix typo in G-Machine

### DIFF
--- a/next/example/gmachine/gmachine-2.md
+++ b/next/example/gmachine/gmachine-2.md
@@ -4,7 +4,7 @@ This article is the second in the series on implementing lazy evaluation in Moon
 
 ## let Expressions
 
-The `let` expression in coref differs slightly from that in MoonBit. A `let` expression can create multiple variables but can only be used within a limited scope. Here is an example:
+The `let` expression in coreF differs slightly from that in MoonBit. A `let` expression can create multiple variables but can only be used within a limited scope. Here is an example:
 
 ```moonbit
 {
@@ -14,7 +14,7 @@ The `let` expression in coref differs slightly from that in MoonBit. A `let` exp
 }
 ```
 
-Equivalent coref expression:
+Equivalent coreF expression:
 
 ```clojure
 (let ([x (add n m)]
@@ -22,7 +22,7 @@ Equivalent coref expression:
   (mul x y)) ;; xy can only be used within let
 ```
 
-It is important to note that coref's `let` expressions must follow a sequential order. For example, the following is not valid:
+It is important to note that coreF's `let` expressions must follow a sequential order. For example, the following is not valid:
 
 ```clojure
 (let ([y (add x 42)]

--- a/next/example/gmachine/gmachine-3.md
+++ b/next/example/gmachine/gmachine-3.md
@@ -108,7 +108,7 @@ We first define a concept: bottom, which conceptually represents a value that ne
 
 > If this condition is not met, it does not necessarily mean that the argument is not needed at all; it may be used only in certain branches and its use is determined at runtime. Such an argument is a typical example of one that should be lazily evaluated.
 
-Let's consider bottom as `false` and non-bottom values as `true`. In this way, all functions in coref can be considered boolean functions. Take `abs` as an example:
+Let's consider bottom as `false` and non-bottom values as `true`. In this way, all functions in coreF can be considered boolean functions. Take `abs` as an example:
 
 ```clojure
 (defn abs[n]


### PR DESCRIPTION
replace coref with coreF

- #607 