### PR TITLE
add doc for customize integer value of constant enum

### DIFF
--- a/next/language/ffi.md
+++ b/next/language/ffi.md
@@ -332,6 +332,26 @@ fn register_callback(callback : () -> Unit) -> Unit {
 ``````
 `````````
 
+### Customize integer value of constant enum
+In all backends of MoonBit, constant enum (`enum` where all constructors have no payload) are translated to integer.
+It is possible to customize the actual integer representation of each constructor,
+by adding `= <integer literal>` after constructor declaration:
+
+```moonbit
+enum SpecialNumbers {
+  Zero = 0
+  One
+  Two
+  Three
+  Ten = 10
+  FourtyTwo = 42
+}
+```
+
+If a constructor's integer value is unspecified,
+it defaults to one plus the value of the previous constructor (or zero for the first constructor).
+This feature is particular useful for binding flags of C libraries.
+
 ## Export Functions
 
 For public functions that are neither methods nor polymorphic, they can be exported by configuring the `exports` field in [link configuration](/toolchain/moon/package.md#link-options).

--- a/next/locales/zh_CN/LC_MESSAGES/language.po
+++ b/next/locales/zh_CN/LC_MESSAGES/language.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MoonBit Document \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-11 18:33+0800\n"
+"POT-Creation-Date: 2025-04-14 16:00+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: zh_CN\n"
@@ -13575,10 +13575,48 @@ msgid ""
 msgstr ""
 
 #: ../../language/ffi.md:335
+msgid "Customize integer value of constant enum"
+msgstr "自定义常量枚举的整数表示"
+
+#: ../../language/ffi.md:336
+msgid ""
+"In all backends of MoonBit, constant enum (`enum` where all constructors "
+"have no payload) are translated to integer. It is possible to customize "
+"the actual integer representation of each constructor, by adding `= "
+"<integer literal>` after constructor declaration:"
+msgstr ""
+"在所有后端，常量枚举（所有构造器都没有参数的枚举）都会被编译成整数。"
+"在此基础上，MoonBit 允许用户自定义常量枚举的构造器的整数表达式。"
+"只需在构造器的声明后加上 `= <整数字面量>` 即可："
+
+#: ../../language/ffi.md:340
+msgid ""
+"enum SpecialNumbers {\n"
+"  Zero = 0\n"
+"  One\n"
+"  Two\n"
+"  Three\n"
+"  Ten = 10\n"
+"  FourtyTwo = 42\n"
+"}\n"
+msgstr ""
+
+#: ../../language/ffi.md:351
+msgid ""
+"If a constructor's integer value is unspecified, it defaults to one plus "
+"the value of the previous constructor (or zero for the first "
+"constructor). This feature is particular useful for binding flags of C "
+"libraries."
+msgstr ""
+"如果一个构造器没有用户指定的整数值，默认的值是上一个构造器的值加一。"
+"（第一个构造器的默认值是 `0`）。"
+"自定义整数表示的功能在绑定一些 C 库里的 flag 是很有用。"
+
+#: ../../language/ffi.md:355
 msgid "Export Functions"
 msgstr "导出函数"
 
-#: ../../language/ffi.md:337
+#: ../../language/ffi.md:357
 msgid ""
 "For public functions that are neither methods nor polymorphic, they can "
 "be exported by configuring the `exports` field in [link "
@@ -13587,7 +13625,7 @@ msgstr ""
 "对于既不是方法也不是多态的公开函数，可以通过配置 [链接选项](/toolchain/moon/package.md#link-options) "
 "中的 `exports` 字段来导出它们。"
 
-#: ../../language/ffi.md:339
+#: ../../language/ffi.md:359
 msgid ""
 "{\n"
 "  \"link\": {\n"
@@ -13598,34 +13636,34 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/ffi.md:349
+#: ../../language/ffi.md:369
 msgid ""
 "The previous example exports functions `add` and `fib`, where `fib` will "
 "be exported as `test`."
 msgstr "上述例子中导出函数 `add` 和 `fib`，其中 `fib` 会被导出为 `test`。"
 
-#: ../../language/ffi.md:357 ../../language/ffi.md:364
-#: ../../language/ffi.md:372
+#: ../../language/ffi.md:377 ../../language/ffi.md:384
+#: ../../language/ffi.md:392
 msgid ""
 "It is only effective for the package that configures it, i.e. it doesn't "
 "affect the downstream packages."
 msgstr "这仅对配置它的包有效，即它不会影响下游包。"
 
-#: ../../language/ffi.md:366
+#: ../../language/ffi.md:386
 msgid ""
 "There's another `format` option to export as CommonJS module (`cjs`), ES "
 "Module (`esm`), or `iife`."
 msgstr "还有另一个 `format` 选项可以导出为 CommonJS 模块（`cjs`）、ES 模块（`esm`）或立即调用的函数表达式（`iife`）。"
 
-#: ../../language/ffi.md:374
+#: ../../language/ffi.md:394
 msgid "Renaming the exported function is not supported for now"
 msgstr "目前不支持重命名导出的函数。"
 
-#: ../../language/ffi.md:379
+#: ../../language/ffi.md:399
 msgid "Lifetime management"
 msgstr "生命周期管理"
 
-#: ../../language/ffi.md:381
+#: ../../language/ffi.md:401
 msgid ""
 "MoonBit is a programming language with garbage collection. Thus when "
 "handling external object or passing MoonBit object to host, it is "
@@ -13636,21 +13674,21 @@ msgstr ""
 "MoonBit 是一门具有垃圾回收的编程语言。因此在处理外部对象或将 MoonBit 对象传递给宿主时，必须牢记生命周期管理。目前，MoonBit"
 " 对 Wasm 后端和 C 后端使用引用计数。对于 Wasm GC 后端和 JavaScript 后端，复用运行时的垃圾回收机制。"
 
-#: ../../language/ffi.md:383
+#: ../../language/ffi.md:403
 msgid "Lifetime management of external object"
 msgstr "外部对象的生命周期管理"
 
-#: ../../language/ffi.md:385
+#: ../../language/ffi.md:405
 msgid ""
 "When handling foreign object/resource in MoonBit, it is important to free"
 " the object/resource in time to prevent memory/resource leak."
 msgstr "在 MoonBit 中处理来自外部的对象和资源时，需要即使释放这些外部对象占用的内存和资源以避免泄漏。"
 
-#: ../../language/ffi.md:388
+#: ../../language/ffi.md:408
 msgid "For C backend only"
 msgstr "仅限 C 后端"
 
-#: ../../language/ffi.md:391
+#: ../../language/ffi.md:411
 msgid ""
 "`moonbit.h` provides an API `moonbit_make_external_object` for handling "
 "lifetime of external object/resource using MoonBit's own automatic memory"
@@ -13659,7 +13697,7 @@ msgstr ""
 "`moonbit.h` 中提供了一个实用的函数 `moonbit_make_external_object`，它可以借助 MoonBit "
 "的自动内存管理系统来管理外部对象的生命周期："
 
-#: ../../language/ffi.md:393
+#: ../../language/ffi.md:413
 msgid ""
 "void *moonbit_make_external_object(\n"
 "  void (*finalize)(void *self),\n"
@@ -13667,7 +13705,7 @@ msgid ""
 ");\n"
 msgstr ""
 
-#: ../../language/ffi.md:400
+#: ../../language/ffi.md:420
 msgid ""
 "`moonbit_make_external_object` will create a new MoonBit object of size "
 "`payload_size + sizeof(finalize)`, the layout of the object is as "
@@ -13676,7 +13714,7 @@ msgstr ""
 "`moonbit_make_external_object` 会创建一个大小为 `payload_size + sizeof(finalize)`"
 " 的新的 MoonBit 对象，这个对象的内存布局如下："
 
-#: ../../language/ffi.md:403
+#: ../../language/ffi.md:423
 msgid ""
 "| MoonBit object header | ... payload | finalize function |\n"
 "                        ^\n"
@@ -13691,7 +13729,7 @@ msgstr ""
 "                 |_\n"
 "                    `moonbit_make_external_object` 返回的指针"
 
-#: ../../language/ffi.md:411
+#: ../../language/ffi.md:431
 msgid ""
 "so you can treat the object as a pointer to its payload directly. When "
 "MoonBit's automatic memory management system finds that an object created"
@@ -13703,13 +13741,13 @@ msgstr ""
 "的自动内存管理系统发现 `moonbit_make_external_object` "
 "返回的对象生命周期已经结束时，它会以对象自身为参数，调用创建对象时提供的 `finalize` 函数来释放这个对象占有的外部资源。"
 
-#: ../../language/ffi.md:414
+#: ../../language/ffi.md:434
 msgid ""
 "`finalize` **must not** drop the object itself, as this is handled by "
 "MoonBit runtime."
 msgstr "`finalize` **绝对不能** 释放对象自身，因为这部分工作由 MoonBit 运行时负责。"
 
-#: ../../language/ffi.md:417
+#: ../../language/ffi.md:437
 msgid ""
 "On the MoonBit side, objects returned by `moonbit_make_external_object` "
 "should be bind to an *abstract* type, declared using `type T`, so that "
@@ -13718,11 +13756,11 @@ msgstr ""
 "在 MoonBit 侧，`moonbit_make_external_object` 返回的对象应当被绑定到 *抽象* 类型，即用 `type "
 "T` 语法声明的类型。这样一来，MoonBit 的内存管理系统就不会无视这个对象。"
 
-#: ../../language/ffi.md:422
+#: ../../language/ffi.md:442
 msgid "Lifetime management of MoonBit object"
 msgstr "MoonBit 对象的生命周期管理"
 
-#: ../../language/ffi.md:424
+#: ../../language/ffi.md:444
 msgid ""
 "When passing MoonBit objects to the host through functions, it is "
 "essential to take care of the lifetime management of MoonBit itself. As "
@@ -13734,15 +13772,15 @@ msgstr ""
 "当通过函数将 MoonBit 对象传递给宿主时，必须注意 MoonBit 对象本身的生命周期管理。如前所述，MoonBit 的 Wasm 后端和 "
 "C 后端使用编译器优化的引用计数来管理对象的生命周期。为了避免内存错误或泄漏，FFI 函数必须正确维护 MoonBit 对象的引用计数。"
 
-#: ../../language/ffi.md:427
+#: ../../language/ffi.md:447
 msgid "For C backend and for Wasm backend only."
 msgstr "仅限 C 后端和 Wasm 后端。"
 
-#: ../../language/ffi.md:430
+#: ../../language/ffi.md:450
 msgid "The calling convention of reference counting"
 msgstr "引用计数的调用约定"
 
-#: ../../language/ffi.md:432
+#: ../../language/ffi.md:452
 msgid ""
 "By default, MoonBit uses an owned calling convention for reference "
 "counting. That is, callee (the function being invoked) is responsible for"
@@ -13756,61 +13794,61 @@ msgstr ""
 "函数来释放它的参数。如果参数被多次使用，被调用的函数需要调用 `moonbit_incref` "
 "函数来增加引用计数。下面是不同场合下维护正确引用计数需要做的操作："
 
-#: ../../language/ffi.md:426
+#: ../../language/ffi.md:446
 msgid "event"
 msgstr "场合"
 
-#: ../../language/ffi.md:426
+#: ../../language/ffi.md:446
 msgid "operation"
 msgstr "操作"
 
-#: ../../language/ffi.md:426
+#: ../../language/ffi.md:446
 msgid "read field/element"
 msgstr "读取字段/元素"
 
-#: ../../language/ffi.md:426
+#: ../../language/ffi.md:446
 msgid "nothing"
 msgstr "什么都不做"
 
-#: ../../language/ffi.md:426
+#: ../../language/ffi.md:446
 msgid "store into data structure"
 msgstr "存储进数据结构"
 
-#: ../../language/ffi.md:426
+#: ../../language/ffi.md:446
 msgid "`incref`"
 msgstr "调用 `incref`"
 
-#: ../../language/ffi.md:426
+#: ../../language/ffi.md:446
 msgid "passed to MoonBit function"
 msgstr "作为参数传递给 MoonBit 函数"
 
-#: ../../language/ffi.md:426
+#: ../../language/ffi.md:446
 msgid "passed to other foreign function"
 msgstr "作为参数传递给其他外部函数"
 
-#: ../../language/ffi.md:426
+#: ../../language/ffi.md:446
 msgid "returned"
 msgstr "作为返回值被返回"
 
-#: ../../language/ffi.md:426
+#: ../../language/ffi.md:446
 msgid "end of scope (not returned)"
 msgstr "作用域结束（且没有返回）"
 
-#: ../../language/ffi.md:426
+#: ../../language/ffi.md:446
 msgid "`decref`"
 msgstr "调用 `decref`"
 
-#: ../../language/ffi.md:443
+#: ../../language/ffi.md:463
 msgid ""
 "For example, here's a lifetime-correct binding to the standard `open` "
 "function for opening a file:"
 msgstr "下面的例子是一个正确维护引用计数的、标准的打开文件的 `open` 函数的绑定："
 
-#: ../../language/ffi.md:445
+#: ../../language/ffi.md:465
 msgid "extern \"C\" open(filename : Bytes, flags : Int) -> Int = \"open_ffi\"\n"
 msgstr ""
 
-#: ../../language/ffi.md:449
+#: ../../language/ffi.md:469
 msgid ""
 "int open_ffi(moonbit_bytes_t filename, int flags) {\n"
 "  int fd = open(filename, flags);\n"
@@ -13819,52 +13857,52 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/ffi.md:457
+#: ../../language/ffi.md:477
 msgid "The managed types"
 msgstr "被管理的类型"
 
-#: ../../language/ffi.md:459
+#: ../../language/ffi.md:479
 msgid ""
 "The following types are always unboxed, so there is no need to manage "
 "their lifetime:"
 msgstr "下面的类型不是分配在堆上的，不需要管理生命周期："
 
-#: ../../language/ffi.md:461
+#: ../../language/ffi.md:481
 msgid "builtin number types, such as `Int` and `Double`"
 msgstr "内置数字类型，例如 `Int` 和 `Double`"
 
-#: ../../language/ffi.md:462
+#: ../../language/ffi.md:482
 msgid "constant `enum` (`enum` where all constructors have no payload)"
 msgstr "常量枚举（所有构造器都不带参数的枚举）"
 
-#: ../../language/ffi.md:464
+#: ../../language/ffi.md:484
 msgid "The following types are always boxed and reference counted:"
 msgstr "下面的类型总是分配在堆上的，并且需要引用计数："
 
-#: ../../language/ffi.md:466
+#: ../../language/ffi.md:486
 msgid "`FixedArray[T]`, `Bytes` and `String`"
 msgstr ""
 
-#: ../../language/ffi.md:467
+#: ../../language/ffi.md:487
 msgid "abstract types (`type T`)"
 msgstr "抽象类型（`type T`）"
 
-#: ../../language/ffi.md:469
+#: ../../language/ffi.md:489
 msgid ""
 "External types (`extern type T`) are also boxed, but they represent "
 "external pointers, so MoonBit will not perform any reference counting "
 "operations on them."
 msgstr "外部类型（`extern type T`）也被分配在堆上，但它们表示外部指针，因此 MoonBit 不会对它们执行任何引用计数操作。"
 
-#: ../../language/ffi.md:472
+#: ../../language/ffi.md:492
 msgid "The layout of `struct`/`enum` with payload is currently unstable."
 msgstr "`struct`/有参数的 `enum` 的内存表示是不稳定的。"
 
-#: ../../language/ffi.md:474
+#: ../../language/ffi.md:494
 msgid "The borrow attribute"
 msgstr "borrow 标记"
 
-#: ../../language/ffi.md:476
+#: ../../language/ffi.md:496
 msgid ""
 "To properly maintain reference count, it is often necessary to write "
 "foreign functions just to perform `decref`. Fortunately, MoonBit provides"
@@ -13874,17 +13912,17 @@ msgstr ""
 "为了正确维护引用计数，往往需要写一个胶水 C 函数来调用 `moonbit_decref`。对这种情况，MoonBit 提供了 `#borrow`"
 " 标记来改变 C FFI 的调用约定，把引用计数的调用约定改为传递借用。`#borrow` 标记的语法是："
 
-#: ../../language/ffi.md:478
+#: ../../language/ffi.md:498
 msgid ""
 "#borrow(params..)\n"
 "extern \"C\" fn c_ffi(..) -> .. = ..\n"
 msgstr ""
 
-#: ../../language/ffi.md:483
+#: ../../language/ffi.md:503
 msgid "where `params` is a subset of the parameters of `c_ffi`."
 msgstr "其中，`params` 是 `c_ffi` 的参数列表的一个子集。"
 
-#: ../../language/ffi.md:485
+#: ../../language/ffi.md:505
 msgid ""
 "Parameters of `#borrow` will be passed using borrow based calling "
 "convention, that is, the invoked function does not need to drop these "
@@ -13898,20 +13936,20 @@ msgstr ""
 "函数只会在运行期间读取它的参数（不会返回它的参数或把它们存进数据结构），那么使用 `#borrow` 标记可以直接绑定 FFI "
 "函数，无需写胶水函数。上面的 `open` 的例子可以使用 `#borrow` 标记来简化："
 
-#: ../../language/ffi.md:487
+#: ../../language/ffi.md:507
 msgid ""
 "#borrow(filename)\n"
 "extern \"C\" fn open(filename : Bytes, flags : Int) -> Int = \"open\"\n"
 msgstr ""
 
-#: ../../language/ffi.md:492
+#: ../../language/ffi.md:512
 msgid ""
 "There is no need for a stub function anymore: we are binding to the "
 "original version of `open` here. With the `#borrow` attribute, this "
 "version is still lifetime-correct."
 msgstr "这里不再需要 C 胶水函数：我们直接绑定到了原版 `open`。`#borrow` 标记保证了这个简化的版本依然能正确维护引用计数。"
 
-#: ../../language/ffi.md:494
+#: ../../language/ffi.md:514
 msgid ""
 "Even if a stub function is still necessary for other reasons, `#borrow` "
 "can often simplify the lifetime management. Here are the rules for the "
@@ -13921,11 +13959,11 @@ msgstr ""
 "即使由于某些其他原因依然需要写 C 胶水函数，`#borrow` 标记也可以用于简化 C 胶水内部的生命周期管理。下面是不同场合下，正确维护 "
 "**借用参数** 的引用计数需要做的操作："
 
-#: ../../language/ffi.md:426
+#: ../../language/ffi.md:446
 msgid "read field / element"
 msgstr "读取字段/元素"
 
-#: ../../language/ffi.md:426
+#: ../../language/ffi.md:446
 msgid "passed to other C function / `#borrow` MoonBit function"
 msgstr "传递给其他 C 函数 / `#borrow` MoonBit 函数"
 


### PR DESCRIPTION
since this feature is only useful for FFI, I placed it in the FFI page. May move to language fundamental page if we allow native conversion to `Int` inside MoonBit in the future.