### PR TITLE
doc(example): add funcref example

### DIFF
--- a/next/sources/language/src/funcref_qsort/moon.pkg.json
+++ b/next/sources/language/src/funcref_qsort/moon.pkg.json
@@ -1,0 +1,14 @@
+{
+  "warn-list": "-1-2-3-4-5-6-9-28",
+  "targets": {
+    "top.mbt": [
+      "native"
+    ]
+  },
+  "native-stub": [
+    "stub.c"
+  ],
+  "supported-targets": [
+    "native"
+  ]
+}

--- a/next/sources/language/src/funcref_qsort/stub.c
+++ b/next/sources/language/src/funcref_qsort/stub.c
@@ -1,0 +1,56 @@
+#include <moonbit.h>
+#define __USE_GNU // to order to use qsort_r
+#include <stdlib.h>
+
+typedef void *moonbit_closure_t;
+typedef void *moonbit_ref_t;
+typedef moonbit_ref_t moonbit_point_t;
+typedef moonbit_point_t *moonbit_fixedarray_point_t;
+
+struct comp_context {
+  int (*call)(moonbit_point_t lhs, moonbit_point_t rhs,
+              moonbit_closure_t closure);
+  moonbit_closure_t closure;
+};
+
+#if defined(_WIN32) || defined(_WIN64) || defined(__APPLE__)
+#include <stdlib.h>
+int comp(struct comp_context *context, moonbit_point_t *lhs,
+         moonbit_point_t *rhs) 
+#else 
+#define __USE_GNU // to order to use qsort_r
+#include <stdlib.h>
+int comp(moonbit_point_t *lhs, moonbit_point_t *rhs,
+         struct comp_context *context) 
+#endif 
+{
+  moonbit_incref(*lhs);
+  moonbit_incref(*rhs);
+  moonbit_incref(context->closure);
+  return context->call(context->closure,*lhs, *rhs);
+}
+
+// https://en.cppreference.com/w/c/algorithm/qsort
+// both glibc and Windows CRT doesn't support ISO C qsort_s
+void ffi_qsort(moonbit_fixedarray_point_t xs,
+               int (*call)(moonbit_closure_t closure,moonbit_point_t lhs, moonbit_point_t rhs),
+               moonbit_closure_t closure) {
+  size_t count = Moonbit_array_length(xs);
+  size_t elem_size = sizeof(moonbit_point_t);
+
+  // struct comp_context *context = malloc(sizeof(struct comp_context));
+  struct comp_context context = {
+    .call = call,
+    .closure = closure,
+  };
+#if defined(_WIN32) || defined(_WIN64)
+  // https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/qsort-s?view=msvc-170
+  qsort_s(xs, count, elem_size, (void *)comp, &context);
+#elif defined(__APPLE__)
+  // https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/qsort_r.3.html
+  qsort_r(xs, count, elem_size, &context, (void *)comp);
+#else
+  // https://www.man7.org/linux/man-pages/man3/qsort.3.html
+  qsort_r(xs, count, elem_size, (void *)comp, &context);
+#endif
+}

--- a/next/sources/language/src/funcref_qsort/top.mbt
+++ b/next/sources/language/src/funcref_qsort/top.mbt
@@ -1,0 +1,44 @@
+///|
+struct Point {
+  x : Int
+  y : Int
+} derive(@quickcheck.Arbitrary, Compare, Eq, Show)
+
+///|
+#borrow(xs, comp)
+extern "c" fn ffi_qsort(
+  xs : FixedArray[Point],
+  comp : FuncRef[((Point, Point) -> Int,Point,Point) -> Int],
+  closure : (Point,Point) -> Int
+) = "ffi_qsort"
+
+
+fn qsort(xs : FixedArray[Point], comp : (Point,Point) -> Int) -> Unit {
+  ffi_qsort(xs,fn(f,x,y) { f(x,y)},comp)
+}
+
+///|
+test {
+  let xs : FixedArray[Point] = @quickcheck.samples(10) |> FixedArray::from_array
+  let ys = xs.copy()
+  let comp : (Point, Point) -> Int = fn(x, y) { x.compare(y) }
+  inspect!(
+    xs,
+    content="[{x: 0, y: 0}, {x: 0, y: 0}, {x: 0, y: -1}, {x: 2, y: 0}, {x: -2, y: 2}, {x: 0, y: 2}, {x: -5, y: -2}, {x: 2, y: 3}, {x: 3, y: 7}, {x: 1, y: 0}]",
+  )
+  inspect!(
+    ys,
+    content="[{x: 0, y: 0}, {x: 0, y: 0}, {x: 0, y: -1}, {x: 2, y: 0}, {x: -2, y: 2}, {x: 0, y: 2}, {x: -5, y: -2}, {x: 2, y: 3}, {x: 3, y: 7}, {x: 1, y: 0}]",
+  )
+  xs |> qsort(comp)
+  ys.sort()
+  inspect!(
+    xs,
+    content="[{x: -5, y: -2}, {x: -2, y: 2}, {x: 0, y: -1}, {x: 0, y: 0}, {x: 0, y: 0}, {x: 0, y: 2}, {x: 1, y: 0}, {x: 2, y: 0}, {x: 2, y: 3}, {x: 3, y: 7}]",
+  )
+  inspect!(
+    ys,
+    content="[{x: -5, y: -2}, {x: -2, y: 2}, {x: 0, y: -1}, {x: 0, y: 0}, {x: 0, y: 0}, {x: 0, y: 2}, {x: 1, y: 0}, {x: 2, y: 0}, {x: 2, y: 3}, {x: 3, y: 7}]",
+  )
+  assert_eq!(xs, ys)
+}

--- a/next/sources/language/src/funcref_qsort_without_stub/moon.pkg.json
+++ b/next/sources/language/src/funcref_qsort_without_stub/moon.pkg.json
@@ -1,0 +1,14 @@
+{
+  "warn-list": "-1-2-3-4-5-6-9-28",
+  "targets": {
+    "top.mbt": [
+      "native"
+    ]
+  },
+  "native-stub": [
+    "stub.c"
+  ],
+  "supported-targets": [
+    "native"
+  ]
+}

--- a/next/sources/language/src/funcref_qsort_without_stub/stub.c
+++ b/next/sources/language/src/funcref_qsort_without_stub/stub.c
@@ -1,0 +1,3 @@
+int ffi_read_int(int* ptr, int idx) {
+  return ptr[idx];
+}

--- a/next/sources/language/src/funcref_qsort_without_stub/top.mbt
+++ b/next/sources/language/src/funcref_qsort_without_stub/top.mbt
@@ -1,0 +1,45 @@
+///|
+extern type ConstPtr[T]
+
+// TODO
+// pub fn ConstPtr::op_get[T](self : ConstPtr[T], index : Int) -> T = "%fixedarray.unsafe_get"
+///|
+extern "c" fn ConstPtr::read_int(self : ConstPtr[Int], index : Int) -> Int = "ffi_read_int"
+
+///|
+fn ConstPtr::deref_int(self : ConstPtr[Int]) -> Int {
+  self.read_int(0)
+}
+
+///|
+#borrow(xs, count, elem_size, comp)
+extern "c" fn qsort_ffi(
+  xs : FixedArray[Int],
+  count : UInt64,
+  elem_size : UInt64,
+  comp : FuncRef[(ConstPtr[Int], ConstPtr[Int]) -> Int]
+) = "qsort"
+
+///|
+fn qsort(
+  xs : FixedArray[Int],
+  comp : FuncRef[(ConstPtr[Int], ConstPtr[Int]) -> Int]
+) -> Unit {
+  qsort_ffi(xs, xs.length().to_uint64(), 4UL, comp)
+}
+
+///|
+test {
+  let xs : FixedArray[Int] = @quickcheck.samples(10) |> FixedArray::from_array
+  let ys = xs.copy()
+  let comp : FuncRef[(ConstPtr[Int], ConstPtr[Int]) -> Int] = fn(x, y) {
+    x.deref_int().compare(y.deref_int())
+  }
+  inspect!(xs, content="[0, 0, 0, -1, -1, 0, 0, -1, 2, 5]")
+  inspect!(ys, content="[0, 0, 0, -1, -1, 0, 0, -1, 2, 5]")
+  xs |> qsort(comp)
+  ys.sort()
+  inspect!(xs, content="[-1, -1, -1, 0, 0, 0, 0, 0, 2, 5]")
+  inspect!(ys, content="[-1, -1, -1, 0, 0, 0, 0, 0, 2, 5]")
+  assert_eq!(xs, ys)
+}

--- a/next/sources/language/src/funcref_register_callback/__snapshot__/funcref.txt
+++ b/next/sources/language/src/funcref_register_callback/__snapshot__/funcref.txt
@@ -1,0 +1,3 @@
+moonbit
+moonbit
+moonbit

--- a/next/sources/language/src/funcref_register_callback/moon.pkg.json
+++ b/next/sources/language/src/funcref_register_callback/moon.pkg.json
@@ -1,0 +1,14 @@
+{
+  "warn-list": "-1-2-3-4-5-6-9-28",
+  "targets": {
+    "top.mbt": [
+      "native"
+    ]
+  },
+  "native-stub": [
+    "stub.c"
+  ],
+  "supported-targets": [
+    "native"
+  ]
+}

--- a/next/sources/language/src/funcref_register_callback/stub.c
+++ b/next/sources/language/src/funcref_register_callback/stub.c
@@ -1,0 +1,17 @@
+#include <moonbit.h>
+
+typedef void* moonbit_closure_t;
+
+// `call` indicates how to consume `closure`
+void register_callback(void (*call)(moonbit_closure_t), moonbit_closure_t closure) {
+  moonbit_incref(closure); 
+  // call closure before must insert `moonbit_incref`
+  // https://github.com/moonbitlang/moonbit-docs/issues/664
+  call(closure); // call closure directly
+  
+  moonbit_incref(closure);
+  call(closure);
+
+  moonbit_incref(closure);
+  call(closure);
+} 

--- a/next/sources/language/src/funcref_register_callback/top.mbt
+++ b/next/sources/language/src/funcref_register_callback/top.mbt
@@ -1,0 +1,23 @@
+///|
+#borrow(call, closure)
+extern "c" fn ffi_register_callback(
+  call : FuncRef[(() -> Unit) -> Unit],
+  closure : () -> Unit
+) = "register_callback"
+
+///|
+fn register_callback(closure : () -> Unit) -> Unit {
+  ffi_register_callback(
+    fn(f) { f() }, // moonc know how to consume `closure`
+    closure,
+  )
+}
+
+///|
+test (t : @test.T) {
+  let s1 = "moonbit"
+  register_callback(fn() {
+    t.writeln(s1) // capture free variables
+  })
+  t.snapshot!(filename="funcref.txt")
+}


### PR DESCRIPTION
we can use `{literalinclude}` markdown extension to embed code snippet info markdown files.

this example intends to replace current `language/ffi` `funcref` example,

This example will be clearer than the current one.