### PR TITLE
docs:  replace `foreign functions` with `functions from other packages`

### DIFF
--- a/next/language/fundamentals.md
+++ b/next/language/fundamentals.md
@@ -600,7 +600,8 @@ MoonBit allows calling functions with alternative names via function alias. Func
 :end-before: end function alias
 ```
 
-Function alias can be used to assign shorter name to foreign functions.
+Function alias can be used to import functions from other packages.
+
 You can also create public function alias with the syntax `pub fnalias`,
 which is useful for re-exporting functions from another package.
 

--- a/next/locales/zh_CN/LC_MESSAGES/language.po
+++ b/next/locales/zh_CN/LC_MESSAGES/language.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MoonBit Document \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-19 10:57+0800\n"
+"POT-Creation-Date: 2025-05-19 11:01+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: zh_CN\n"
@@ -1815,15 +1815,15 @@ msgstr ""
 
 #: ../../language/error-handling.md:111 ../../language/fundamentals.md:117
 #: ../../language/fundamentals.md:149 ../../language/fundamentals.md:206
-#: ../../language/fundamentals.md:255 ../../language/fundamentals.md:696
-#: ../../language/fundamentals.md:710 ../../language/fundamentals.md:724
-#: ../../language/fundamentals.md:738 ../../language/fundamentals.md:750
-#: ../../language/fundamentals.md:767 ../../language/fundamentals.md:805
-#: ../../language/fundamentals.md:852 ../../language/fundamentals.md:866
-#: ../../language/fundamentals.md:1000 ../../language/fundamentals.md:1036
-#: ../../language/fundamentals.md:1067 ../../language/fundamentals.md:1094
-#: ../../language/fundamentals.md:1123 ../../language/fundamentals.md:1143
-#: ../../language/fundamentals.md:1177 ../../language/fundamentals.md:1191
+#: ../../language/fundamentals.md:255 ../../language/fundamentals.md:697
+#: ../../language/fundamentals.md:711 ../../language/fundamentals.md:725
+#: ../../language/fundamentals.md:739 ../../language/fundamentals.md:751
+#: ../../language/fundamentals.md:768 ../../language/fundamentals.md:806
+#: ../../language/fundamentals.md:853 ../../language/fundamentals.md:867
+#: ../../language/fundamentals.md:1001 ../../language/fundamentals.md:1037
+#: ../../language/fundamentals.md:1068 ../../language/fundamentals.md:1095
+#: ../../language/fundamentals.md:1124 ../../language/fundamentals.md:1144
+#: ../../language/fundamentals.md:1178 ../../language/fundamentals.md:1192
 #: ../../language/methods.md:91
 msgid "Output"
 msgstr "输出"
@@ -10839,7 +10839,7 @@ msgid ""
 "follows:"
 msgstr ""
 
-#: ../../language/error_codes/E4095.md ../../language/fundamentals.md:1269
+#: ../../language/error_codes/E4095.md ../../language/fundamentals.md:1270
 msgid "Type"
 msgstr "类型"
 
@@ -10853,7 +10853,7 @@ msgstr "映射值"
 msgid "Maximum value"
 msgstr "映射值"
 
-#: ../../language/error_codes/E4095.md ../../language/fundamentals.md:1269
+#: ../../language/error_codes/E4095.md ../../language/fundamentals.md:1270
 msgid "Byte"
 msgstr "字节"
 
@@ -15107,7 +15107,7 @@ msgstr ""
 msgid "API: <https://mooncakes.io/docs/moonbitlang/core/string>"
 msgstr ""
 
-#: ../../language/fundamentals.md:169 ../../language/fundamentals.md:1269
+#: ../../language/fundamentals.md:169 ../../language/fundamentals.md:1270
 msgid "Char"
 msgstr "字符"
 
@@ -16010,29 +16010,32 @@ msgstr ""
 ")\n"
 
 #: ../../language/fundamentals.md:603
+msgid "Function alias can be used to import functions from other packages."
+msgstr "函数别名可以用于从其他包中导入函数。"
+
+#: ../../language/fundamentals.md:605
 msgid ""
-"Function alias can be used to assign shorter name to foreign functions. "
 "You can also create public function alias with the syntax `pub fnalias`, "
 "which is useful for re-exporting functions from another package."
 msgstr ""
-"函数别名可以用来给来自外部的函数提供更短的名字，方便调用。此外，也可以用 `pub fnalias` "
+"此外，也可以用 `pub fnalias` "
 "语法来定义公开的函数别名，公开的函数别名可以用于将来自外部的函数在当前包重新导出。"
 
-#: ../../language/fundamentals.md:607
+#: ../../language/fundamentals.md:608
 msgid "Control Structures"
 msgstr "控制结构"
 
-#: ../../language/fundamentals.md:609
+#: ../../language/fundamentals.md:610
 msgid "Conditional Expressions"
 msgstr "条件表达式"
 
-#: ../../language/fundamentals.md:611
+#: ../../language/fundamentals.md:612
 msgid ""
 "A conditional expression consists of a condition, a consequent, and an "
 "optional `else` clause or `else if` clause."
 msgstr "条件表达式由条件、结果和可选的 `else` 子句或 `else if` 子句组成。"
 
-#: ../../language/fundamentals.md:613
+#: ../../language/fundamentals.md:614
 msgid ""
 "if x == y {\n"
 "  expr1\n"
@@ -16043,37 +16046,37 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:620
+#: ../../language/fundamentals.md:621
 msgid "The curly brackets around the consequent are required."
 msgstr "结果周围的大括号是必需的。"
 
-#: ../../language/fundamentals.md:622
+#: ../../language/fundamentals.md:623
 msgid ""
 "Note that a conditional expression always returns a value in MoonBit, and"
 " the return values of the consequent and the else clause must be of the "
 "same type. Here is an example:"
 msgstr "请注意，条件表达式在 MoonBit 中始终返回一个值，结果和 else 子句的返回值必须是相同的类型。以下是一个示例："
 
-#: ../../language/fundamentals.md:624
+#: ../../language/fundamentals.md:625
 msgid "let initial = if size < 1 { 1 } else { size }\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:631
+#: ../../language/fundamentals.md:632
 msgid "The `else` clause can only be omitted if the return value has type `Unit`."
 msgstr "`else` 子句只有在返回值的类型为 `Unit`的时候省略。"
 
-#: ../../language/fundamentals.md:633
+#: ../../language/fundamentals.md:634
 msgid "Match Expression"
 msgstr "匹配表达式"
 
-#: ../../language/fundamentals.md:635
+#: ../../language/fundamentals.md:636
 msgid ""
 "The `match` expression is similar to conditional expression, but it uses "
 "[pattern matching](#pattern-matching) to decide which consequent to "
 "evaluate and extracting variables at the same time."
 msgstr "`match` 表达式类似于条件表达式，但它使用 [模式匹配](#pattern-matching) 来决定要评估哪个结果，并同时提取变量。"
 
-#: ../../language/fundamentals.md:637
+#: ../../language/fundamentals.md:638
 msgid ""
 "fn decide_sport(weather : String, humidity : Int) -> String {\n"
 "  match weather {\n"
@@ -16088,17 +16091,17 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:644
+#: ../../language/fundamentals.md:645
 msgid ""
 "If a possible condition is omitted, the compiler will issue a warning, "
 "and the program will terminate if that case were reached."
 msgstr "如果省略了可能的条件，编译器将发出警告；如果真的出现该情况，程序将终止。"
 
-#: ../../language/fundamentals.md:646
+#: ../../language/fundamentals.md:647
 msgid "Guard Statement"
 msgstr "卫语句"
 
-#: ../../language/fundamentals.md:648
+#: ../../language/fundamentals.md:649
 msgid ""
 "The `guard` statement is used to check a specified invariant. If the "
 "condition of the invariant is satisfied, the program continues executing "
@@ -16109,7 +16112,7 @@ msgstr ""
 "`guard` 语句用于检查指定的不变量。如果不变量的条件得到满足，程序将继续执行后续语句。如果条件不满足（即为假），则执行 `else` "
 "块中的代码且返回其值（并跳过后续语句）。"
 
-#: ../../language/fundamentals.md:653
+#: ../../language/fundamentals.md:654
 msgid ""
 "fn guarded_get(array : Array[Int], index : Int) -> Int? {\n"
 "  guard index >= 0 && index < array.length() else { None }\n"
@@ -16121,11 +16124,11 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:660
+#: ../../language/fundamentals.md:661
 msgid "Guard statement and is expression"
 msgstr "卫语句与 is 表达式"
 
-#: ../../language/fundamentals.md:662
+#: ../../language/fundamentals.md:663
 msgid ""
 "The `let` statement can be used with [pattern matching](#pattern-"
 "matching). However, `let` statement can only handle one case. And using "
@@ -16135,7 +16138,7 @@ msgstr ""
 "`let` 语句可以与 [模式匹配](#pattern-matching) 一起使用。但是，`let` 语句只能处理一种情况。使用 [is 表达式"
 "](#is-expression) 配合卫语句可以解决这个问题。"
 
-#: ../../language/fundamentals.md:664
+#: ../../language/fundamentals.md:665
 msgid ""
 "In the following example, `getProcessedText` assumes that the input "
 "`path` points to resources that are all plain text, and it uses the "
@@ -16146,7 +16149,7 @@ msgstr ""
 "在以下示例中，`getProcessedText` 假设输入的 `path` 指向的资源都是纯文本，并使用 `guard` "
 "语句来在确保这个不变量的同时，解构出纯文本资源。与使用 `match` 语句相比，`text` 的后续处理可以少一级缩进。"
 
-#: ../../language/fundamentals.md:668
+#: ../../language/fundamentals.md:669
 msgid ""
 "enum Resource {\n"
 "  Folder(Array[String])\n"
@@ -16168,24 +16171,24 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:674
+#: ../../language/fundamentals.md:675
 msgid ""
 "When the `else` part is omitted, the program terminates if the condition "
 "specified in the `guard` statement is not true or cannot be matched."
 msgstr "如果省略了 `else` 部分，程序将在 `guard` 语句中指定的条件不为真或无法匹配时终止。"
 
-#: ../../language/fundamentals.md:677
+#: ../../language/fundamentals.md:678
 msgid ""
 "guard condition  // <=> guard condition else { panic() }\n"
 "guard expr is Some(x)\n"
 "// <=> guard expr is Some(x) else { _ => panic() }\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:684
+#: ../../language/fundamentals.md:685
 msgid "While loop"
 msgstr "While 循环"
 
-#: ../../language/fundamentals.md:686
+#: ../../language/fundamentals.md:687
 msgid ""
 "In MoonBit, `while` loop can be used to execute a block of code "
 "repeatedly as long as a condition is true. The condition is evaluated "
@@ -16197,7 +16200,7 @@ msgstr ""
 "在 MoonBit 中，`while` 循环可用于在条件为真时重复执行一段代码块。在执行代码块之前，将评估条件。使用 `while` 关键字定义 "
 "`while` 循环，后跟条件和循环体。循环体是一系列语句。只要条件为真，就会执行循环体。"
 
-#: ../../language/fundamentals.md:688
+#: ../../language/fundamentals.md:689
 msgid ""
 "fn main {\n"
 "  let mut i = 5\n"
@@ -16208,7 +16211,7 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:696
+#: ../../language/fundamentals.md:697
 msgid ""
 "5\n"
 "4\n"
@@ -16217,7 +16220,7 @@ msgid ""
 "1\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:700
+#: ../../language/fundamentals.md:701
 msgid ""
 "The loop body supports `break` and `continue`. Using `break` allows you "
 "to exit the current loop, while using `continue` skips the remaining part"
@@ -16226,7 +16229,7 @@ msgstr ""
 "循环体支持 `break` 和 `continue`。使用 `break` 可以退出当前循环，而使用 `continue` "
 "则跳过当前迭代的剩余部分并继续下一次迭代。"
 
-#: ../../language/fundamentals.md:702
+#: ../../language/fundamentals.md:703
 msgid ""
 "fn main {\n"
 "  let mut i = 5\n"
@@ -16243,20 +16246,20 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:710
+#: ../../language/fundamentals.md:711
 msgid ""
 "3\n"
 "2\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:714
+#: ../../language/fundamentals.md:715
 msgid ""
 "The `while` loop also supports an optional `else` clause. When the loop "
 "condition becomes false, the `else` clause will be executed, and then the"
 " loop will end."
 msgstr "`while` 循环还支持可选的 `else` 子句。当循环条件变为假时，将执行 `else` 子句，然后循环将结束。"
 
-#: ../../language/fundamentals.md:716
+#: ../../language/fundamentals.md:717
 msgid ""
 "fn main {\n"
 "  let mut i = 2\n"
@@ -16269,14 +16272,14 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:724
+#: ../../language/fundamentals.md:725
 msgid ""
 "2\n"
 "1\n"
 "0\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:728
+#: ../../language/fundamentals.md:729
 msgid ""
 "When there is an `else` clause, the `while` loop can also return a value."
 " The return value is the evaluation result of the `else` clause. In this "
@@ -16287,7 +16290,7 @@ msgstr ""
 "当有 `else` 子句时，`while` 循环还可以返回一个值。返回值是 `else` 子句的评估结果。在这种情况下，如果使用 `break` "
 "退出循环，需要在 `break` 后提供一个返回值，该返回值应与 `else` 子句的返回值类型相同。"
 
-#: ../../language/fundamentals.md:730
+#: ../../language/fundamentals.md:731
 msgid ""
 "fn main {\n"
 "  let mut i = 10\n"
@@ -16303,11 +16306,11 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:738
+#: ../../language/fundamentals.md:739
 msgid "5\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:742
+#: ../../language/fundamentals.md:743
 msgid ""
 "fn main {\n"
 "  let mut i = 10\n"
@@ -16320,15 +16323,15 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:750
+#: ../../language/fundamentals.md:751
 msgid "7\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:754
+#: ../../language/fundamentals.md:755
 msgid "For Loop"
 msgstr "For 循环"
 
-#: ../../language/fundamentals.md:756
+#: ../../language/fundamentals.md:757
 msgid ""
 "MoonBit also supports C-style For loops. The keyword `for` is followed by"
 " variable initialization clauses, loop conditions, and update clauses "
@@ -16341,7 +16344,7 @@ msgstr ""
 "后跟由分号分隔的变量初始化子句、循环条件和更新子句。它们不需要用括号括起来。例如，下面的代码创建了一个新的变量绑定 "
 "`i`，它在整个循环中都有作用域且是不可变的。这使得编写清晰的代码并对其进行推理更容易："
 
-#: ../../language/fundamentals.md:759
+#: ../../language/fundamentals.md:760
 msgid ""
 "fn main {\n"
 "  for i = 0; i < 5; i = i + 1 {\n"
@@ -16350,7 +16353,7 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:767
+#: ../../language/fundamentals.md:768
 msgid ""
 "0\n"
 "1\n"
@@ -16359,18 +16362,18 @@ msgid ""
 "4\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:771
+#: ../../language/fundamentals.md:772
 msgid "The variable initialization clause can create multiple bindings:"
 msgstr "变量初始化子句可以创建多个绑定："
 
-#: ../../language/fundamentals.md:773
+#: ../../language/fundamentals.md:774
 msgid ""
 "for i = 0, j = 0; i + j < 100; i = i + 1, j = j + 1 {\n"
 "  println(i)\n"
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:780
+#: ../../language/fundamentals.md:781
 msgid ""
 "It should be noted that in the update clause, when there are multiple "
 "binding variables, the semantics are to update them simultaneously. In "
@@ -16383,13 +16386,13 @@ msgstr ""
 "应该注意，在更新子句中，当有多个绑定变量时，语义是同时更新它们。换句话说，在上面的示例中，更新子句不会按顺序执行 `i = i + 1`，`j ="
 " j + 1`，而是同时递增 `i` 和 `j`。因此，在更新子句中读取绑定变量的值时，总是会得到上一次迭代中更新的值。"
 
-#: ../../language/fundamentals.md:782
+#: ../../language/fundamentals.md:783
 msgid ""
 "Variable initialization clauses, loop conditions, and update clauses are "
 "all optional. For example, the following two are infinite loops:"
 msgstr "变量初始化子句、循环条件和更新子句都是可选的。例如，以下两个是无限循环："
 
-#: ../../language/fundamentals.md:784
+#: ../../language/fundamentals.md:785
 msgid ""
 "for i = 1; ; i = i + 1 {\n"
 "  println(i)\n"
@@ -16399,7 +16402,7 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:791
+#: ../../language/fundamentals.md:792
 msgid ""
 "The `for` loop also supports `continue`, `break`, and `else` clauses. "
 "Like the `while` loop, the `for` loop can also return a value using the "
@@ -16408,7 +16411,7 @@ msgstr ""
 "`for` 循环还支持 `continue`、`break` 和 `else` 子句。与 `while` 循环一样，`for` 循环也可以使用 "
 "`break` 和 `else` 子句返回一个值。"
 
-#: ../../language/fundamentals.md:793
+#: ../../language/fundamentals.md:794
 msgid ""
 "The `continue` statement skips the remaining part of the current "
 "iteration of the `for` loop (including the update clause) and proceeds to"
@@ -16419,13 +16422,13 @@ msgstr ""
 "`continue` 语句跳过当前 `for` 循环的剩余部分（包括更新子句）并继续下一次迭代。`continue` 语句还可以更新 `for` "
 "循环的绑定变量，只要后面跟着与绑定变量数量匹配的表达式，用逗号分隔。"
 
-#: ../../language/fundamentals.md:795
+#: ../../language/fundamentals.md:796
 msgid ""
 "For example, the following program calculates the sum of even numbers "
 "from 1 to 6:"
 msgstr "例如，以下程序计算从 1 到 6 的偶数之和："
 
-#: ../../language/fundamentals.md:797
+#: ../../language/fundamentals.md:798
 msgid ""
 "fn main {\n"
 "  let sum = for i = 1, acc = 0; i <= 6; i = i + 1 {\n"
@@ -16440,7 +16443,7 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:805
+#: ../../language/fundamentals.md:806
 msgid ""
 "even: 2\n"
 "even: 4\n"
@@ -16448,24 +16451,24 @@ msgid ""
 "12\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:809
+#: ../../language/fundamentals.md:810
 msgid "`for .. in` loop"
 msgstr "`for .. in` 循环"
 
-#: ../../language/fundamentals.md:811
+#: ../../language/fundamentals.md:812
 msgid ""
 "MoonBit supports traversing elements of different data structures and "
 "sequences via the `for .. in` loop syntax:"
 msgstr "MoonBit 支持通过 `for .. in` 循环语法遍历不同数据结构和序列的元素："
 
-#: ../../language/fundamentals.md:813
+#: ../../language/fundamentals.md:814
 msgid ""
 "for x in [1, 2, 3] {\n"
 "  println(x)\n"
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:820
+#: ../../language/fundamentals.md:821
 msgid ""
 "`for .. in` loop is translated to the use of `Iter` in MoonBit's standard"
 " library. Any type with a method `.iter() : Iter[T]` can be traversed "
@@ -16475,13 +16478,13 @@ msgstr ""
 "`for .. in` 循环被转换为在 MoonBit 标准库中使用 `Iter`。任何具有方法 `.iter() : Iter[T]` "
 "的类型都可以使用 `for .. in` 进行遍历。有关 `Iter` 类型的更多信息，请参见下面的 [迭代器](#iterator)。"
 
-#: ../../language/fundamentals.md:823
+#: ../../language/fundamentals.md:824
 msgid ""
 "`for .. in` loop also supports iterating through a sequence of integers, "
 "such as:"
 msgstr "`for .. in` 循环还支持遍历整数序列，例如："
 
-#: ../../language/fundamentals.md:825
+#: ../../language/fundamentals.md:826
 msgid ""
 "test {\n"
 "  let mut i = 0\n"
@@ -16497,7 +16500,7 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:832
+#: ../../language/fundamentals.md:833
 msgid ""
 "In addition to sequences of a single value, MoonBit also supports "
 "traversing sequences of two values, such as `Map`, via the `Iter2` type "
@@ -16507,7 +16510,7 @@ msgstr ""
 "除了单个值的序列外，MoonBit 还支持通过 MoonBit 标准库中的 `Iter2` 类型遍历两个值的序列，例如 `Map`。任何具有方法 "
 "`.iter2() : Iter2[A, B]` 的类型都可以使用两个循环变量的 `for .. in` 进行遍历："
 
-#: ../../language/fundamentals.md:835
+#: ../../language/fundamentals.md:836
 msgid ""
 "for k, v in { \"x\": 1, \"y\": 2, \"z\": 3 } {\n"
 "  println(k)\n"
@@ -16515,13 +16518,13 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:842
+#: ../../language/fundamentals.md:843
 msgid ""
 "Another example of `for .. in` with two loop variables is traversing an "
 "array while keeping track of array index:"
 msgstr "另一个使用两个循环变量的 `for .. in` 的示例是在遍历数组时跟踪数组索引："
 
-#: ../../language/fundamentals.md:844
+#: ../../language/fundamentals.md:845
 msgid ""
 "fn main {\n"
 "  for index, elem in [4, 5, 6] {\n"
@@ -16531,20 +16534,20 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:852
+#: ../../language/fundamentals.md:853
 msgid ""
 "The 1-th element of the array is 4\n"
 "The 2-th element of the array is 5\n"
 "The 3-th element of the array is 6\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:856
+#: ../../language/fundamentals.md:857
 msgid ""
 "Control flow operations such as `return`, `break` and error handling are "
 "supported in the body of `for .. in` loop:"
 msgstr "`for .. in` 循环的主体支持诸如 `return`、`break` 和错误处理等控制流操作："
 
-#: ../../language/fundamentals.md:858
+#: ../../language/fundamentals.md:859
 msgid ""
 "fn main {\n"
 "  let map = { \"x\": 1, \"y\": 2, \"z\": 3, \"w\": 4 }\n"
@@ -16560,27 +16563,27 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:866
+#: ../../language/fundamentals.md:867
 msgid ""
 "x, 1\n"
 "z, 3\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:870
+#: ../../language/fundamentals.md:871
 msgid "If a loop variable is unused, it can be ignored with `_`."
 msgstr "如果循环变量未使用，可以使用 `_` 忽略它。"
 
-#: ../../language/fundamentals.md:872
+#: ../../language/fundamentals.md:873
 msgid "Functional loop"
 msgstr "函数式循环"
 
-#: ../../language/fundamentals.md:874
+#: ../../language/fundamentals.md:875
 msgid ""
 "Functional loop is a powerful feature in MoonBit that enables you to "
 "write loops in a functional style."
 msgstr "函数式循环是 MoonBit 中的一个强大功能，它使您可以以函数式风格编写循环。"
 
-#: ../../language/fundamentals.md:876
+#: ../../language/fundamentals.md:877
 msgid ""
 "A functional loop consumes arguments and returns a value. It is defined "
 "using the `loop` keyword, followed by its arguments and the loop body. "
@@ -16598,7 +16601,7 @@ msgstr ""
 " `continue` 关键字和参数进入循环的下一次迭代。使用 `break` "
 "关键字和参数从循环中返回一个值。如果值是循环体中的最后一个表达式，则可以省略 `break` 关键字。"
 
-#: ../../language/fundamentals.md:878
+#: ../../language/fundamentals.md:879
 msgid ""
 "test {\n"
 "  fn sum(xs : @immut/list.T[Int]) -> Int {\n"
@@ -16612,23 +16615,23 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:885
+#: ../../language/fundamentals.md:886
 msgid ""
 "Currently in `loop exprs { ... }`, `exprs` is nonempty list, while `for {"
 " ... }` is accepted for infinite loop."
 msgstr "目前在 `loop exprs { ... }` 中，`exprs` 是非空列表，而 `for { ... }` 用于无限循环。"
 
-#: ../../language/fundamentals.md:888
+#: ../../language/fundamentals.md:889
 msgid "Labelled Continue/Break"
 msgstr "带标记的 Continue/Break"
 
-#: ../../language/fundamentals.md:890
+#: ../../language/fundamentals.md:891
 msgid ""
 "When a loop is labelled, it can be referenced from a `break` or "
 "`continue` from within a nested loop. For example:"
 msgstr "当一个循环被标记的时候，它可以从循环中的 `break` 或者 `continue` 中引用，例如："
 
-#: ../../language/fundamentals.md:893
+#: ../../language/fundamentals.md:894
 msgid ""
 "test \"break label\" {\n"
 "  let mut count = 0\n"
@@ -16663,11 +16666,11 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:899
+#: ../../language/fundamentals.md:900
 msgid "Iterator"
 msgstr "迭代器"
 
-#: ../../language/fundamentals.md:901
+#: ../../language/fundamentals.md:902
 msgid ""
 "An iterator is an object that traverse through a sequence while providing"
 " access to its elements. Traditional OO languages like Java's "
@@ -16682,14 +16685,14 @@ msgstr ""
 "和`hasNext()` 来遍历迭代过程，而函数式语言（JavaScript 的 `forEach`，Lisp 的 "
 "`mapcar`）提供了一个高阶函数，该函数接受一个操作和一个序列，然后使用该操作应用于序列。前者称为外部迭代器（对用户可见），后者称为内部迭代器（对用户不可见）。"
 
-#: ../../language/fundamentals.md:909
+#: ../../language/fundamentals.md:910
 msgid ""
 "The built-in type `Iter[T]` is MoonBit's internal iterator "
 "implementation. Almost all built-in sequential data structures have "
 "implemented `Iter`:"
 msgstr "内置类型 `Iter[T]` 是 MoonBit 的内部迭代器实现。几乎所有内置的顺序数据结构都已经实现了 `Iter`："
 
-#: ../../language/fundamentals.md:912
+#: ../../language/fundamentals.md:913
 msgid ""
 "///|\n"
 "fn filter_even(l : Array[Int]) -> Array[Int] {\n"
@@ -16705,45 +16708,45 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:918
+#: ../../language/fundamentals.md:919
 msgid "Commonly used methods include:"
 msgstr "常用的方法包括："
 
-#: ../../language/fundamentals.md:920
+#: ../../language/fundamentals.md:921
 msgid ""
 "`each`: Iterates over each element in the iterator, applying some "
 "function to each element."
 msgstr "`each`: 遍历迭代器中的每个元素，对每个元素应用某个函数。"
 
-#: ../../language/fundamentals.md:921
+#: ../../language/fundamentals.md:922
 msgid ""
 "`fold`: Folds the elements of the iterator using the given function, "
 "starting with the given initial value."
 msgstr "`fold`: 使用给定的函数，从给定的初始值开始，对迭代器的元素进行“折叠”。"
 
-#: ../../language/fundamentals.md:922
+#: ../../language/fundamentals.md:923
 msgid "`collect`: Collects the elements of the iterator into an array."
 msgstr "`collect`: 将迭代器的元素收集到一个数组中。"
 
-#: ../../language/fundamentals.md:924
+#: ../../language/fundamentals.md:925
 msgid ""
 "`filter`: _lazy_ Filters the elements of the iterator based on a "
 "predicate function."
 msgstr "`filter`: （惰性）根据谓词函数过滤迭代器的元素。"
 
-#: ../../language/fundamentals.md:925
+#: ../../language/fundamentals.md:926
 msgid ""
 "`map`: _lazy_ Transforms the elements of the iterator using a mapping "
 "function."
 msgstr "`map`: （惰性）使用映射函数转换迭代器的元素。"
 
-#: ../../language/fundamentals.md:926
+#: ../../language/fundamentals.md:927
 msgid ""
 "`concat`: _lazy_ Combines two iterators into one by appending the "
 "elements of the second iterator to the first."
 msgstr "`concat`: （惰性）通过将第二个迭代器的元素附加到第一个迭代器，将两个迭代器合并为一个。"
 
-#: ../../language/fundamentals.md:928
+#: ../../language/fundamentals.md:929
 msgid ""
 "Methods like `filter` `map` are very common on a sequence object e.g. "
 "Array. But what makes `Iter` special is that any method that constructs a"
@@ -16757,7 +16760,7 @@ msgstr ""
 " 的方法都是**惰性**的（即在调用时不会开始迭代，因为它被包装在一个函数内），因此不会为中间值分配内存。这就是使 `Iter` "
 "优于遍历序列的原因：没有额外的成本。MoonBit 鼓励用户将 `Iter` 传递给函数，而不是传递序列对象本身。"
 
-#: ../../language/fundamentals.md:936
+#: ../../language/fundamentals.md:937
 msgid ""
 "Pre-defined sequence structures like `Array` and its iterators should be "
 "enough to use. But to take advantages of these methods when used with a "
@@ -16768,7 +16771,7 @@ msgstr ""
 "预定义的序列结构如 `Array` 及其迭代器应该足够使用。但是，为了在自定义序列（元素类型为 `S`）中使用这些方法，我们需要实现 "
 "`Iter`，即返回 `Iter[S]` 的函数。以 `Bytes` 为例："
 
-#: ../../language/fundamentals.md:941
+#: ../../language/fundamentals.md:942
 msgid ""
 "///|\n"
 "fn iter(data : Bytes) -> Iter[Byte] {\n"
@@ -16783,18 +16786,18 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:947
+#: ../../language/fundamentals.md:948
 msgid ""
 "Almost all `Iter` implementations are identical to that of `Bytes`, the "
 "only main difference being the code block that actually does the "
 "iteration."
 msgstr "几乎所有 `Iter` 实现都与 `Bytes` 的实现相同，唯一的主要区别是实际执行迭代的代码块。"
 
-#: ../../language/fundamentals.md:950
+#: ../../language/fundamentals.md:951
 msgid "Implementation details"
 msgstr "实现细节"
 
-#: ../../language/fundamentals.md:952
+#: ../../language/fundamentals.md:953
 msgid ""
 "The type `Iter[T]` is basically a type alias for `((T) -> IterResult) -> "
 "IterResult`, a higher-order function that takes an operation and "
@@ -16804,17 +16807,17 @@ msgstr ""
 "类型 `Iter[T]` 基本上是 `((T) -> IterResult) -> IterResult` "
 "的类型别名，它是一个高阶函数，接受一个操作，`IterResult` 是一个枚举对象，用于跟踪当前迭代的状态，包含以下 2 种状态："
 
-#: ../../language/fundamentals.md:957
+#: ../../language/fundamentals.md:958
 msgid "`IterEnd`: marking the end of an iteration"
 msgstr "`IterEnd`: 标记迭代结束"
 
-#: ../../language/fundamentals.md:958
+#: ../../language/fundamentals.md:959
 msgid ""
 "`IterContinue`: marking the end of an iteration is yet to be reached, "
 "implying the iteration will still continue at this state."
 msgstr "`IterContinue`: 标记迭代结束尚未到达，暗示迭代将在此状态继续"
 
-#: ../../language/fundamentals.md:960
+#: ../../language/fundamentals.md:961
 msgid ""
 "To put it simply, `Iter[T]` takes a function `(T) -> IterResult` and use "
 "it to transform `Iter[T]` itself to a new state of type `IterResult`. "
@@ -16824,21 +16827,21 @@ msgstr ""
 "简单来说，`Iter[T]` 接受一个函数 `(T) -> IterResult` 并使用它将 `Iter[T]` 本身转换为类型为 "
 "`IterResult` 的新状态。"
 
-#: ../../language/fundamentals.md:964
+#: ../../language/fundamentals.md:965
 msgid ""
 "Iterator provides a unified way to iterate through data structures, and "
 "they can be constructed at basically no cost: as long as `fn(yield)` "
 "doesn't execute, the iteration process doesn't start."
 msgstr "迭代器提供了一种统一的遍历数据结构的方式，它们基本上可以无成本地构建：只要 `fn(yield)` 不执行，迭代过程就不会开始。"
 
-#: ../../language/fundamentals.md:968
+#: ../../language/fundamentals.md:969
 msgid ""
 "Internally a `Iter::run()` is used to trigger the iteration. Chaining all"
 " sorts of `Iter` methods might be visually pleasing, but do notice the "
 "heavy work underneath the abstraction."
 msgstr "`Iter::run()` 在在内部触发迭代。链接各种 `Iter` 方法可能看起来很美观，但请注意抽象层下面的繁重工作。"
 
-#: ../../language/fundamentals.md:972
+#: ../../language/fundamentals.md:973
 msgid ""
 "Thus, unlike an external iterator, once the iteration starts there's no "
 "way to stop unless the end is reached. Methods such as `count()` which "
@@ -16849,19 +16852,19 @@ msgstr ""
 "因此，与外部迭代器不同，一旦迭代开始，除非到达末尾，否则无法停止。诸如 `count()` 这样的方法，它计算迭代器中元素的数量看起来像是一个 "
 "`O(1)` 操作，但实际上具有线性时间复杂度。请谨慎使用迭代器，否则可能会出现性能问题。"
 
-#: ../../language/fundamentals.md:978
+#: ../../language/fundamentals.md:979
 msgid "Custom Data Types"
 msgstr "自定义数据类型"
 
-#: ../../language/fundamentals.md:980
+#: ../../language/fundamentals.md:981
 msgid "There are two ways to create new data types: `struct` and `enum`."
 msgstr "创建新数据类型有两种方法：`struct` 和 `enum`。"
 
-#: ../../language/fundamentals.md:982
+#: ../../language/fundamentals.md:983
 msgid "Struct"
 msgstr "结构体"
 
-#: ../../language/fundamentals.md:984
+#: ../../language/fundamentals.md:985
 msgid ""
 "In MoonBit, structs are similar to tuples, but their fields are indexed "
 "by field names. A struct can be constructed using a struct literal, which"
@@ -16875,7 +16878,7 @@ msgstr ""
 "中，结构体类似于元组，但其字段由字段名称索引。可以使用结构体字面量构造结构体，结构体字面量由一组带标签的值组成，并用大括号括起来。如果结构体的字段与类型定义完全匹配，那么结构体字面量的类型可以自动推断。可以使用点语法"
 " `s.f` 访问字段。如果使用关键字 `mut` 标记字段为可变的，则可以为其分配新值。"
 
-#: ../../language/fundamentals.md:986
+#: ../../language/fundamentals.md:987
 msgid ""
 "struct User {\n"
 "  id : Int\n"
@@ -16884,7 +16887,7 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:992
+#: ../../language/fundamentals.md:993
 msgid ""
 "fn main {\n"
 "  let u = User::{ id: 0, name: \"John Doe\", email: \"john@doe.com\" }\n"
@@ -16896,52 +16899,52 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1000
+#: ../../language/fundamentals.md:1001
 msgid ""
 "0\n"
 "John Doe\n"
 "john@doe.name\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1004
+#: ../../language/fundamentals.md:1005
 msgid "Constructing Struct with Shorthand"
 msgstr "使用简写构造结构体"
 
-#: ../../language/fundamentals.md:1006
+#: ../../language/fundamentals.md:1007
 msgid ""
 "If you already have some variable like `name` and `email`, it's redundant"
 " to repeat those names when constructing a struct. You can use shorthand "
 "instead, it behaves exactly the same:"
 msgstr "如果已经有一些变量，如 `name` 和 `email`，在构造结构体时重复这些名称是多余的。可以使用简写，它的行为完全相同："
 
-#: ../../language/fundamentals.md:1008
+#: ../../language/fundamentals.md:1009
 msgid ""
 "let name = \"john\"\n"
 "let email = \"john@doe.com\"\n"
 "let u = User::{ id: 0, name, email }\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1015
+#: ../../language/fundamentals.md:1016
 msgid ""
 "If there's no other struct that has the same fields, it's redundant to "
 "add the struct's name when constructing it:"
 msgstr "如果没有其他具有相同字段的结构体，在构造结构体时添加结构体的名称是多余的："
 
-#: ../../language/fundamentals.md:1017
+#: ../../language/fundamentals.md:1018
 msgid "let u2 = { id : 0, name, email }\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1024
+#: ../../language/fundamentals.md:1025
 msgid "Struct Update Syntax"
 msgstr "结构体更新语法"
 
-#: ../../language/fundamentals.md:1026
+#: ../../language/fundamentals.md:1027
 msgid ""
 "It's useful to create a new struct based on an existing one, but with "
 "some fields updated."
 msgstr "可以用这个语法来根据现有结构体创建一个新的结构体，但只更新部分字段。"
 
-#: ../../language/fundamentals.md:1028
+#: ../../language/fundamentals.md:1029
 msgid ""
 "fn main {\n"
 "  let user = { id: 0, name: \"John Doe\", email: \"john@doe.com\" }\n"
@@ -16955,23 +16958,23 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1036
+#: ../../language/fundamentals.md:1037
 msgid ""
 "{ id: 0, name: John Doe, email: john@doe.com }\n"
 "{ id: 0, name: John Doe, email: john@doe.name }\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1040
+#: ../../language/fundamentals.md:1041
 msgid "Enum"
 msgstr "枚举"
 
-#: ../../language/fundamentals.md:1042
+#: ../../language/fundamentals.md:1043
 msgid ""
 "Enum types are similar to algebraic data types in functional languages. "
 "Users familiar with C/C++ may prefer calling it tagged union."
 msgstr "枚举类型类似于函数式语言中的代数数据类型。熟悉 C/C++ 的用户可能更喜欢称其为标记联合。"
 
-#: ../../language/fundamentals.md:1044
+#: ../../language/fundamentals.md:1045
 msgid ""
 "An enum can have a set of cases (constructors). Constructor names must "
 "start with capitalized letter. You can use these names to construct "
@@ -16979,7 +16982,7 @@ msgid ""
 "belongs to in pattern matching:"
 msgstr "枚举可以有一组情况（构造函数）。构造函数的名称必须以大写字母开头。可以使用这些名称来构造枚举的相应情况，或在模式匹配中检查枚举值属于哪个分支："
 
-#: ../../language/fundamentals.md:1046
+#: ../../language/fundamentals.md:1047
 msgid ""
 "/// An enum type that represents the ordering relation between two "
 "values,\n"
@@ -16998,7 +17001,7 @@ msgstr ""
 "  Equal\n"
 "}\n"
 
-#: ../../language/fundamentals.md:1052
+#: ../../language/fundamentals.md:1053
 msgid ""
 "/// compare the ordering relation between two integers\n"
 "fn compare_int(x : Int, y : Int) -> Relation {\n"
@@ -17058,7 +17061,7 @@ msgstr ""
 "  }\n"
 "}\n"
 
-#: ../../language/fundamentals.md:1059
+#: ../../language/fundamentals.md:1060
 msgid ""
 "fn main {\n"
 "  print_relation(compare_int(0, 1))\n"
@@ -17067,20 +17070,20 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1067
+#: ../../language/fundamentals.md:1068
 msgid ""
 "smaller!\n"
 "equal!\n"
 "greater!\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1071
+#: ../../language/fundamentals.md:1072
 msgid ""
 "Enum cases can also carry payload data. Here's an example of defining an "
 "integer list type using enum:"
 msgstr "枚举情况也可以携带额外数据。以下是使用枚举定义整数列表类型的示例："
 
-#: ../../language/fundamentals.md:1073
+#: ../../language/fundamentals.md:1074
 msgid ""
 "enum List {\n"
 "  Nil\n"
@@ -17097,7 +17100,7 @@ msgstr ""
 "  Cons(Int, List)\n"
 "}\n"
 
-#: ../../language/fundamentals.md:1079
+#: ../../language/fundamentals.md:1080
 msgid ""
 "// In addition to binding payload to variables,\n"
 "// you can also continue matching payload data inside constructors.\n"
@@ -17161,7 +17164,7 @@ msgstr ""
 "  }\n"
 "}\n"
 
-#: ../../language/fundamentals.md:1086
+#: ../../language/fundamentals.md:1087
 msgid ""
 "fn main {\n"
 "  // when creating values using `Cons`, the payload of by `Cons` must be "
@@ -17178,7 +17181,7 @@ msgstr ""
 "  print_list(l)\n"
 "}\n"
 
-#: ../../language/fundamentals.md:1094
+#: ../../language/fundamentals.md:1095
 msgid ""
 "false\n"
 "1,\n"
@@ -17186,15 +17189,15 @@ msgid ""
 "nil\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1098
+#: ../../language/fundamentals.md:1099
 msgid "Constructor with labelled arguments"
 msgstr "构造器与带标签参数"
 
-#: ../../language/fundamentals.md:1100
+#: ../../language/fundamentals.md:1101
 msgid "Enum constructors can have labelled argument:"
 msgstr "枚举构造器可以有带标签的参数："
 
-#: ../../language/fundamentals.md:1102
+#: ../../language/fundamentals.md:1103
 msgid ""
 "enum E {\n"
 "  // `x` and `y` are labelled argument\n"
@@ -17206,7 +17209,7 @@ msgstr ""
 "  C(x~ : Int, y~ : Int)\n"
 "}\n"
 
-#: ../../language/fundamentals.md:1108
+#: ../../language/fundamentals.md:1109
 msgid ""
 "// pattern matching constructor with labelled arguments\n"
 "fn f(e : E) -> Unit {\n"
@@ -17230,7 +17233,7 @@ msgstr ""
 "  }\n"
 "}\n"
 
-#: ../../language/fundamentals.md:1115
+#: ../../language/fundamentals.md:1116
 msgid ""
 "fn main {\n"
 "  f(C(x=0, y=0))\n"
@@ -17239,19 +17242,19 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1123
+#: ../../language/fundamentals.md:1124
 msgid ""
 "0!\n"
 "0\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1127
+#: ../../language/fundamentals.md:1128
 msgid ""
 "It is also possible to access labelled arguments of constructors like "
 "accessing struct fields in pattern matching:"
 msgstr "也可以像在模式匹配中访问结构体字段一样访问构造函数的有标签参数："
 
-#: ../../language/fundamentals.md:1129
+#: ../../language/fundamentals.md:1130
 msgid ""
 "enum Object {\n"
 "  Point(x~ : Double, y~ : Double)\n"
@@ -17303,7 +17306,7 @@ msgstr ""
 "}\n"
 "\n"
 
-#: ../../language/fundamentals.md:1135
+#: ../../language/fundamentals.md:1136
 msgid ""
 "fn main {\n"
 "  let p1 : Object = Point(x=0, y=0)\n"
@@ -17318,23 +17321,23 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1143
+#: ../../language/fundamentals.md:1144
 msgid ""
 "5\n"
 "NotImplementedError\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1147
+#: ../../language/fundamentals.md:1148
 msgid "Constructor with mutable fields"
 msgstr "构造器与可变字段"
 
-#: ../../language/fundamentals.md:1149
+#: ../../language/fundamentals.md:1150
 msgid ""
 "It is also possible to define mutable fields for constructor. This is "
 "especially useful for defining imperative data structures:"
 msgstr "也可以为构造器定义可变字段。这对于定义命令式数据结构特别有用："
 
-#: ../../language/fundamentals.md:1151
+#: ../../language/fundamentals.md:1152
 msgid ""
 "// A set implemented using mutable binary search tree.\n"
 "struct Set[X] {\n"
@@ -17431,15 +17434,15 @@ msgstr ""
 "  }\n"
 "}\n"
 
-#: ../../language/fundamentals.md:1157
+#: ../../language/fundamentals.md:1158
 msgid "Newtype"
 msgstr "Newtype"
 
-#: ../../language/fundamentals.md:1159
+#: ../../language/fundamentals.md:1160
 msgid "MoonBit supports a special kind of enum called newtype:"
 msgstr "MoonBit 支持一种特殊的枚举称为 newtype："
 
-#: ../../language/fundamentals.md:1161
+#: ../../language/fundamentals.md:1162
 msgid ""
 "// `UserId` is a fresh new type different from `Int`, \n"
 "// and you can define new methods for `UserId`, etc.\n"
@@ -17457,7 +17460,7 @@ msgstr ""
 "\n"
 "type UserName String\n"
 
-#: ../../language/fundamentals.md:1167
+#: ../../language/fundamentals.md:1168
 msgid ""
 "Newtypes are similar to enums with only one constructor (with the same "
 "name as the newtype itself). So, you can use the constructor to create "
@@ -17467,7 +17470,7 @@ msgstr ""
 "Newtype 类似于只有一个构造函数的枚举（与 newtype 本身的名称相同）。因此，可以使用构造函数创建 newtype "
 "的值，或使用模式匹配提取 newtype 的底层表示："
 
-#: ../../language/fundamentals.md:1169
+#: ../../language/fundamentals.md:1170
 msgid ""
 "fn main {\n"
 "  let id : UserId = UserId(1)\n"
@@ -17479,19 +17482,19 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1177
+#: ../../language/fundamentals.md:1178
 msgid ""
 "1\n"
 "John Doe\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1181
+#: ../../language/fundamentals.md:1182
 msgid ""
 "Besides pattern matching, you can also use `._` to extract the internal "
 "representation of newtypes:"
 msgstr "除了模式匹配，还可以使用 `._` 提取 newtype 的内部表示："
 
-#: ../../language/fundamentals.md:1183
+#: ../../language/fundamentals.md:1184
 msgid ""
 "fn main {\n"
 "  let id : UserId = UserId(1)\n"
@@ -17500,19 +17503,19 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1191
+#: ../../language/fundamentals.md:1192
 msgid "1\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1195
+#: ../../language/fundamentals.md:1196
 msgid "Type alias"
 msgstr "类型别名"
 
-#: ../../language/fundamentals.md:1196
+#: ../../language/fundamentals.md:1197
 msgid "MoonBit supports type alias via the syntax `typealias Name = TargetType`:"
 msgstr "MoonBit 支持使用语法 `typealias Name = TargetType` 定义类型别名："
 
-#: ../../language/fundamentals.md:1198
+#: ../../language/fundamentals.md:1199
 msgid ""
 "pub typealias Index = Int\n"
 "\n"
@@ -17524,7 +17527,7 @@ msgstr ""
 "// 类型别名默认为私有\n"
 "typealias MapString[X] = Map[String, X]\n"
 
-#: ../../language/fundamentals.md:1204
+#: ../../language/fundamentals.md:1205
 msgid ""
 "Unlike all other kinds of type declaration above, type alias does not "
 "define a new type, it is merely a type macro that behaves exactly the "
@@ -17532,11 +17535,11 @@ msgid ""
 "implement traits for a type alias."
 msgstr "与上面所有其他类型声明不同，类型别名不定义新类型，它只是一个行为与其定义完全相同的类型宏。因此，例如，不能为类型别名定义新方法或实现特征。"
 
-#: ../../language/fundamentals.md:1209
+#: ../../language/fundamentals.md:1210
 msgid "Type alias can be used to perform incremental code refactor."
 msgstr "类型别名可用于执行增量代码重构。"
 
-#: ../../language/fundamentals.md:1211
+#: ../../language/fundamentals.md:1212
 msgid ""
 "For example, if you want to move a type `T` from `@pkgA` to `@pkgB`, you "
 "can leave a type alias `typealias T = @pkgB.T` in `@pkgA`, and "
@@ -17546,11 +17549,11 @@ msgstr ""
 "例如，如果要将类型 `T` 从 `@pkgA` 移动到 `@pkgB`，可以在 `@pkgA` 中留下一个类型别名 `typealias T = "
 "@pkgB.T`，"
 
-#: ../../language/fundamentals.md:1216
+#: ../../language/fundamentals.md:1217
 msgid "Local types"
 msgstr "本地类型"
 
-#: ../../language/fundamentals.md:1218
+#: ../../language/fundamentals.md:1219
 msgid ""
 "Moonbit supports declaring structs/enums/newtypes at the top of a "
 "toplevel function, which are only visible within the current toplevel "
@@ -17563,7 +17566,7 @@ msgstr ""
 "支持在顶层函数的顶部声明结构体/枚举/newtype，这些类型仅在当前顶层函数中可见。这些本地类型可以使用顶层函数的泛型参数，但不能引入额外的泛型参数。本地类型可以使用"
 " derive 派生方法，但不能手动定义额外的方法。例如："
 
-#: ../../language/fundamentals.md:1225
+#: ../../language/fundamentals.md:1226
 msgid ""
 "fn toplevel[T: Show](x: T) -> Unit {\n"
 "  enum LocalEnum {\n"
@@ -17578,63 +17581,63 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1231
+#: ../../language/fundamentals.md:1232
 msgid "Currently, local types do not support being declared as error types."
 msgstr "目前，本地类型不支持声明为错误类型。"
 
-#: ../../language/fundamentals.md:1233
+#: ../../language/fundamentals.md:1234
 msgid "Pattern Matching"
 msgstr "模式匹配"
 
-#: ../../language/fundamentals.md:1235
+#: ../../language/fundamentals.md:1236
 msgid ""
 "Pattern matching allows us to match on specific pattern and bind data "
 "from data structures."
 msgstr "模式匹配允许我们匹配特定模式并从数据结构中绑定数据。"
 
-#: ../../language/fundamentals.md:1237
+#: ../../language/fundamentals.md:1238
 msgid "Simple Patterns"
 msgstr "简单模式"
 
-#: ../../language/fundamentals.md:1239
+#: ../../language/fundamentals.md:1240
 msgid "We can pattern match expressions against"
 msgstr "我们可以将表达式与以下内容进行模式匹配："
 
-#: ../../language/fundamentals.md:1241
+#: ../../language/fundamentals.md:1242
 msgid "literals, such as boolean values, numbers, chars, strings, etc"
 msgstr "字面量，例如布尔值、数字、字符、字符串等"
 
-#: ../../language/fundamentals.md:1242
+#: ../../language/fundamentals.md:1243
 msgid "constants"
 msgstr "常量"
 
-#: ../../language/fundamentals.md:1243
+#: ../../language/fundamentals.md:1244
 msgid "structs"
 msgstr "结构体"
 
-#: ../../language/fundamentals.md:1244
+#: ../../language/fundamentals.md:1245
 msgid "enums"
 msgstr "枚举"
 
-#: ../../language/fundamentals.md:1245
+#: ../../language/fundamentals.md:1246
 msgid "arrays"
 msgstr "数组"
 
-#: ../../language/fundamentals.md:1246
+#: ../../language/fundamentals.md:1247
 msgid "maps"
 msgstr "键值对"
 
-#: ../../language/fundamentals.md:1247
+#: ../../language/fundamentals.md:1248
 msgid "JSONs"
 msgstr "JSON"
 
-#: ../../language/fundamentals.md:1249
+#: ../../language/fundamentals.md:1250
 msgid ""
 "and so on. We can define identifiers to bind the matched values so that "
 "they can be used later."
 msgstr "等等。我们可以定义标识符来绑定匹配的值，以便稍后使用。"
 
-#: ../../language/fundamentals.md:1251
+#: ../../language/fundamentals.md:1252
 msgid ""
 "const ONE = 1\n"
 "\n"
@@ -17647,7 +17650,7 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1258
+#: ../../language/fundamentals.md:1259
 msgid ""
 "We can use `_` as wildcards for the values we don't care about, and use "
 "`..` to ignore remaining fields of struct or enum, or array (see [array "
@@ -17656,7 +17659,7 @@ msgstr ""
 "我们可以使用 `_` 作为我们不关心的值的通配符，并使用 `..` 忽略结构体或枚举的剩余字段，或数组（参见 [数组模式](#array-"
 "pattern)）。"
 
-#: ../../language/fundamentals.md:1260
+#: ../../language/fundamentals.md:1261
 msgid ""
 "struct Point3D {\n"
 "  x : Int\n"
@@ -17685,7 +17688,7 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1267
+#: ../../language/fundamentals.md:1268
 msgid ""
 "We can use `as` to give a name to some pattern, and we can use `|` to "
 "match several cases at once. A variable name can only be bound once in a "
@@ -17695,7 +17698,7 @@ msgstr ""
 "我们可以使用 `as` 为某些模式命名，可以使用 `|` 一次匹配多个情况。在单个模式中，变量名只能绑定一次，并且在 `|` "
 "模式的两侧应绑定相同的变量集。"
 
-#: ../../language/fundamentals.md:1269
+#: ../../language/fundamentals.md:1270
 msgid ""
 "match expr {\n"
 "  //! Add(e1, e2) | Lit(e1) => ...\n"
@@ -17705,75 +17708,75 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1276
+#: ../../language/fundamentals.md:1277
 msgid "Array Pattern"
 msgstr "数组模式"
 
-#: ../../language/fundamentals.md:1278
+#: ../../language/fundamentals.md:1279
 msgid ""
 "Array patterns can be used to match on the following types to obtain "
 "their corresponding elements or views:"
 msgstr "数组模式可以用来匹配以下类型以获取其对应的元素或视图（View）："
 
-#: ../../language/fundamentals.md:1269
+#: ../../language/fundamentals.md:1270
 msgid "Element"
 msgstr "元素"
 
-#: ../../language/fundamentals.md:1269
+#: ../../language/fundamentals.md:1270
 msgid "View"
 msgstr "视图"
 
-#: ../../language/fundamentals.md:1269
+#: ../../language/fundamentals.md:1270
 msgid "Array[T], @array.View[T]"
 msgstr ""
 
-#: ../../language/fundamentals.md:1269
+#: ../../language/fundamentals.md:1270
 msgid "T"
 msgstr ""
 
-#: ../../language/fundamentals.md:1269
+#: ../../language/fundamentals.md:1270
 msgid "@array.View[T]"
 msgstr ""
 
-#: ../../language/fundamentals.md:1269
+#: ../../language/fundamentals.md:1270
 msgid "Bytes, @bytes.View"
 msgstr ""
 
-#: ../../language/fundamentals.md:1269
+#: ../../language/fundamentals.md:1270
 msgid "@bytes.View"
 msgstr ""
 
-#: ../../language/fundamentals.md:1269
+#: ../../language/fundamentals.md:1270
 msgid "String, @string.View"
 msgstr ""
 
-#: ../../language/fundamentals.md:1269
+#: ../../language/fundamentals.md:1270
 msgid "@string.View"
 msgstr ""
 
-#: ../../language/fundamentals.md:1269
+#: ../../language/fundamentals.md:1270
 msgid "FixedArray[T]"
 msgstr "FixedArray[T]"
 
-#: ../../language/fundamentals.md:1269
+#: ../../language/fundamentals.md:1270
 msgid "N/A"
 msgstr "N/A"
 
-#: ../../language/fundamentals.md:1288
+#: ../../language/fundamentals.md:1289
 msgid "Array patterns have the following forms:"
 msgstr "数组模式可以有以下形式："
 
-#: ../../language/fundamentals.md:1290
+#: ../../language/fundamentals.md:1291
 msgid "`[]` : matching for empty array"
 msgstr "`[]`：匹配空数组"
 
-#: ../../language/fundamentals.md:1291
+#: ../../language/fundamentals.md:1292
 msgid ""
 "`[pa, pb, pc]` : matching for array of length three, and bind `pa`, `pb`,"
 " `pc` to the three elements"
 msgstr "`[pa, pb, pc]`：匹配长度为 3 的数组，并将其中的元素分别绑定到 `pa`, `pb`, `pc`"
 
-#: ../../language/fundamentals.md:1293
+#: ../../language/fundamentals.md:1294
 msgid ""
 "`[pa, ..rest, pb]` : matching for array with at least two elements, and "
 "bind `pa` to the first element, `pb` to the last element, and `rest` to "
@@ -17786,7 +17789,7 @@ msgstr ""
 "`rest`。如果不需要其余元素，可以省略绑定 `rest`。在 `..` 部分前后允许任意数量的元素。由于 `..` "
 "可以匹配不确定数量的元素，因此在数组模式中最多只能出现一次。"
 
-#: ../../language/fundamentals.md:1300
+#: ../../language/fundamentals.md:1301
 msgid ""
 "test {\n"
 "  let ary = [1, 2, 3, 4]\n"
@@ -17800,7 +17803,7 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1306
+#: ../../language/fundamentals.md:1307
 msgid ""
 "Array patterns provide a unicode-safe way to manipulate strings, meaning "
 "that it respects the code unit boundaries. For example, we can check if a"
@@ -17809,7 +17812,7 @@ msgstr ""
 "数组模式提供了一种 Unicode 安全的方式来操作字符串，这意味着它在访问元素的时候不会跨越代码单元边界。例如，我们可以检查一个包含 "
 "Unicode 的字符串是否是回文："
 
-#: ../../language/fundamentals.md:1310
+#: ../../language/fundamentals.md:1311
 msgid ""
 "test {\n"
 "  fn palindrome(s: String) -> Bool {\n"
@@ -17824,7 +17827,7 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1316
+#: ../../language/fundamentals.md:1317
 msgid ""
 "When there are consecutive char or byte constants in an array pattern, "
 "the pattern spread `..` operator can be used to combine them to make the "
@@ -17835,7 +17838,7 @@ msgstr ""
 "当数组模式中有连续的字符或字节常量时，可以使用模式展开 `..` 运算符将它们组合起来，使代码看起来更整洁。在这种情况下，`..` "
 "后跟字符串或字节常量匹配确切数量的元素，因此它可以在数组模式中多次使用。"
 
-#: ../../language/fundamentals.md:1321
+#: ../../language/fundamentals.md:1322
 msgid ""
 "const NO: Bytes = \"no\"\n"
 "test {\n"
@@ -17852,17 +17855,17 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1327
+#: ../../language/fundamentals.md:1328
 msgid "Range Pattern"
 msgstr "范围模式"
 
-#: ../../language/fundamentals.md:1328
+#: ../../language/fundamentals.md:1329
 msgid ""
 "For builtin integer types and `Char`, MoonBit allows matching whether the"
 " value falls in a specific range."
 msgstr "对于内置整数类型和 `Char`，MoonBit 允许匹配值是否落在特定范围内。"
 
-#: ../../language/fundamentals.md:1330
+#: ../../language/fundamentals.md:1331
 msgid ""
 "Range patterns have the form `a..<b` or `a..=b`, where `..<` means the "
 "upper bound is exclusive, and `..=` means inclusive upper bound. `a` and "
@@ -17871,23 +17874,23 @@ msgstr ""
 "范围模式的形式为 `a..<b` 或 `a..=b`，其中 `..<` 表示上限是排他的，`..=` 表示包含上限。`a` 和 `b` "
 "可以是以下之一："
 
-#: ../../language/fundamentals.md:1333
+#: ../../language/fundamentals.md:1334
 msgid "literal"
 msgstr "字面量"
 
-#: ../../language/fundamentals.md:1334
+#: ../../language/fundamentals.md:1335
 msgid "named constant declared with `const`"
 msgstr "使用 `const` 声明的常量"
 
-#: ../../language/fundamentals.md:1335
+#: ../../language/fundamentals.md:1336
 msgid "`_`, meaning the pattern has no restriction on this side"
 msgstr "`_`，表示此模式在此侧没有限制"
 
-#: ../../language/fundamentals.md:1337
+#: ../../language/fundamentals.md:1338
 msgid "Here are some examples:"
 msgstr "以下是一些示例："
 
-#: ../../language/fundamentals.md:1339
+#: ../../language/fundamentals.md:1340
 msgid ""
 "const Zero = 0\n"
 "\n"
@@ -17909,11 +17912,11 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1346
+#: ../../language/fundamentals.md:1347
 msgid "Map Pattern"
 msgstr "Map 模式"
 
-#: ../../language/fundamentals.md:1348
+#: ../../language/fundamentals.md:1349
 msgid ""
 "MoonBit allows convenient matching on map-like data structures. Inside a "
 "map pattern, the `key : value` syntax will match if `key` exists in the "
@@ -17925,7 +17928,7 @@ msgstr ""
 "`key` 时匹配，并将 `key` 的值与模式 `value` 匹配。`key? : value` 语法将无论 `key` "
 "是否存在都匹配，`value` 将与 `map[key]`（一个可选项）匹配。"
 
-#: ../../language/fundamentals.md:1352
+#: ../../language/fundamentals.md:1353
 msgid ""
 "match map {\n"
 "  // matches if any only if \"b\" exists in `map`\n"
@@ -17946,7 +17949,7 @@ msgstr ""
 "  // 编译器报告缺失的情况：{ \"b\"? : None, \"a\"? : None }\n"
 "}\n"
 
-#: ../../language/fundamentals.md:1359
+#: ../../language/fundamentals.md:1360
 msgid ""
 "To match a data type `T` using map pattern, `T` must have a method "
 "`op_get(Self, K) -> Option[V]` for some type `K` and `V` (see [method and"
@@ -17955,33 +17958,33 @@ msgstr ""
 "要使用 map 模式匹配数据类型 `T`，`T` 必须具有某种类型 `K` 和 `V` 的方法 `op_get(Self, K) -> "
 "Option[V]`（请参见 [方法和特征](./methods.md)）。"
 
-#: ../../language/fundamentals.md:1360
+#: ../../language/fundamentals.md:1361
 msgid "Currently, the key part of map pattern must be a literal or constant"
 msgstr "目前，map 模式的键部分必须是字面量或常量"
 
-#: ../../language/fundamentals.md:1361
+#: ../../language/fundamentals.md:1362
 msgid ""
 "Map patterns are always open: the unmatched keys are silently ignored, "
 "and `..` needs to be added to identify this nature"
 msgstr "Map 模式始终是开放的：未匹配的键会被静默忽略，并且需要添加 `..` 以显示这一点"
 
-#: ../../language/fundamentals.md:1362
+#: ../../language/fundamentals.md:1363
 msgid ""
 "Map pattern will be compiled to efficient code: every key will be fetched"
 " at most once"
 msgstr "Map 模式将编译为高效的代码：每个键最多只会被获取一次"
 
-#: ../../language/fundamentals.md:1364
+#: ../../language/fundamentals.md:1365
 msgid "Json Pattern"
 msgstr "Json 模式"
 
-#: ../../language/fundamentals.md:1366
+#: ../../language/fundamentals.md:1367
 msgid ""
 "When the matched value has type `Json`, literal patterns can be used "
 "directly, together with constructors:"
 msgstr "当匹配的值具有类型 `Json` 时，可以直接使用字面量模式，以及构造函数："
 
-#: ../../language/fundamentals.md:1368
+#: ../../language/fundamentals.md:1369
 msgid ""
 "match json {\n"
 "  { \"version\": \"1.0.0\", \"import\": [..] as imports, .. } => ...\n"
@@ -17990,11 +17993,11 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1375
+#: ../../language/fundamentals.md:1376
 msgid "Guard condition"
 msgstr "守卫条件"
 
-#: ../../language/fundamentals.md:1377
+#: ../../language/fundamentals.md:1378
 msgid ""
 "Each case in a pattern matching expression can have a guard condition. A "
 "guard condition is a boolean expression that must be true for the case to"
@@ -18002,7 +18005,7 @@ msgid ""
 " next case is tried. For example:"
 msgstr "模式匹配表达式中的每个分支都可以有一个守卫条件。守卫条件是一个布尔表达式，只有当该条件为真时，对应的分支才会被匹配。如果守卫条件为假，则跳过该分支并尝试下一个分支。例如："
 
-#: ../../language/fundamentals.md:1381
+#: ../../language/fundamentals.md:1382
 msgid ""
 "fn guard_cond(x : Int?) -> Int {\n"
 "  fn f(x : Int) -> Array[Int] {\n"
@@ -18023,14 +18026,14 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1388
+#: ../../language/fundamentals.md:1389
 msgid ""
 "Note that the guard conditions will not be considered when checking if "
 "all patterns are covered by the match expression. So you will see a "
 "warning of partial match for the following case:"
 msgstr "注意，在检查所有模式是否都被匹配表达式覆盖时，不会考虑守卫条件。因此，您会看到以下情况的警告："
 
-#: ../../language/fundamentals.md:1392
+#: ../../language/fundamentals.md:1393
 msgid ""
 "fn guard_check(x: Int?) -> Unit {\n"
 "  match x {\n"
@@ -18041,7 +18044,7 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1400
+#: ../../language/fundamentals.md:1401
 msgid ""
 "It is not encouraged to call a function that mutates a part of the value "
 "being matched inside a guard condition. When such case happens, the part "
@@ -18049,11 +18052,11 @@ msgid ""
 " with caution."
 msgstr "不鼓励在守卫条件中调用可能通过副作用改变被匹配的值的函数。在这种情况下，被改变的部分不会在后续模式中重新求值。请谨慎使用。"
 
-#: ../../language/fundamentals.md:1405
+#: ../../language/fundamentals.md:1406
 msgid "Generics"
 msgstr "泛型"
 
-#: ../../language/fundamentals.md:1407
+#: ../../language/fundamentals.md:1408
 msgid ""
 "Generics are supported in top-level function and data type definitions. "
 "Type parameters can be introduced within square brackets. We can rewrite "
@@ -18064,7 +18067,7 @@ msgstr ""
 "泛型在顶层函数和数据类型定义中受支持。可以在方括号内引入类型参数。我们可以重写上述数据类型 `List`，添加类型参数 `T` "
 "以获得列表的通用版本。然后，我们可以定义列表上的通用函数，如 `map` 和 `reduce`。"
 
-#: ../../language/fundamentals.md:1409
+#: ../../language/fundamentals.md:1410
 msgid ""
 "enum List[T] {\n"
 "  Nil\n"
@@ -18086,21 +18089,21 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1413
+#: ../../language/fundamentals.md:1414
 msgid "Special Syntax"
 msgstr "特殊语法"
 
-#: ../../language/fundamentals.md:1415
+#: ../../language/fundamentals.md:1416
 msgid "Pipelines"
 msgstr "管道"
 
-#: ../../language/fundamentals.md:1417
+#: ../../language/fundamentals.md:1418
 msgid ""
 "MoonBit provides a convenient pipe syntax `x |> f(y)`, which can be used "
 "to chain regular function calls:"
 msgstr "MoonBit 提供了一个方便的管道语法`x |> f(y)`，可以用于链接常规函数调用："
 
-#: ../../language/fundamentals.md:1419
+#: ../../language/fundamentals.md:1420
 msgid ""
 "5 |> ignore // <=> ignore(5)\n"
 "[] |> Array::push(5) // <=> Array::push([], 5)\n"
@@ -18109,7 +18112,7 @@ msgid ""
 "|> ignore // <=> ignore(add(1, 5))\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1426
+#: ../../language/fundamentals.md:1427
 msgid ""
 "The MoonBit code follows the *data-first* style, meaning the function "
 "places its \"subject\" as the first argument.  Thus, the pipe operator "
@@ -18121,7 +18124,7 @@ msgstr ""
 "代码遵循*数据优先*风格，也就是说，函数将它的“主题”放置在第一个参数的位置。所以，管道默认将左侧的值填入右侧的函数调用的第一个参数的位置。例如`x"
 " |> f(y)`等价于`f(x,y)`。"
 
-#: ../../language/fundamentals.md:1430
+#: ../../language/fundamentals.md:1431
 msgid ""
 "You can use the `_` operator to insert `x` into any argument of the "
 "function `f`, such as `x |> f(y, _)`, which is equivalent to `f(y, x)`. "
@@ -18130,25 +18133,25 @@ msgstr ""
 "你也可以使用`_`操作符改变`x`在函数`f`的调用中的插入位置，例如`x |> f(y, _)`, "
 "这等价于`f(y,x)`。带标签的参数也是支持的。"
 
-#: ../../language/fundamentals.md:1433
+#: ../../language/fundamentals.md:1434
 msgid "Cascade Operator"
 msgstr "级联运算符"
 
-#: ../../language/fundamentals.md:1435
+#: ../../language/fundamentals.md:1436
 msgid ""
 "The cascade operator `..` is used to perform a series of mutable "
 "operations on the same value consecutively. The syntax is as follows:"
 msgstr "级联运算符`..`用于连续对同一值执行一系列可变操作。语法如下："
 
-#: ../../language/fundamentals.md:1438
+#: ../../language/fundamentals.md:1439
 msgid "x..f()\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1445
+#: ../../language/fundamentals.md:1446
 msgid "`x..f()..g()` is equivalent to `{x.f(); x.g(); x}`."
 msgstr "`x..f()..g()` 等价于 `{x.f(); x.g(); x}`。"
 
-#: ../../language/fundamentals.md:1447
+#: ../../language/fundamentals.md:1448
 msgid ""
 "Consider the following scenario: for a `StringBuilder` type that has "
 "methods like `write_string`, `write_char`, `write_object`, etc., we often"
@@ -18156,7 +18159,7 @@ msgid ""
 "value:"
 msgstr "考虑以下情况：对于具有诸如`write_string`，`write_char`，`write_object`等方法的`StringBuilder`类型，我们经常需要对同一`StringBuilder`值执行一系列操作："
 
-#: ../../language/fundamentals.md:1451
+#: ../../language/fundamentals.md:1452
 msgid ""
 "let builder = StringBuilder::new()\n"
 "builder.write_char('a')\n"
@@ -18166,7 +18169,7 @@ msgid ""
 "let result = builder.to_string()\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1458
+#: ../../language/fundamentals.md:1459
 msgid ""
 "To avoid repetitive typing of `builder`, its methods are often designed "
 "to return `self` itself, allowing operations to be chained using the `.` "
@@ -18178,7 +18181,7 @@ msgstr ""
 "为了避免重复输入`builder`，其方法通常设计为返回`self`本身，允许使用`.`运算符链接操作。为了区分不可变和可变操作，在 "
 "MoonBit 中，对于所有返回`Unit`的方法，可以使用级联运算符进行连续操作，而无需修改方法的返回类型。"
 
-#: ../../language/fundamentals.md:1464
+#: ../../language/fundamentals.md:1465
 msgid ""
 "let result = StringBuilder::new()\n"
 "  ..write_char('a')\n"
@@ -18188,18 +18191,18 @@ msgid ""
 "  .to_string()\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1471
+#: ../../language/fundamentals.md:1472
 msgid "Is Expression"
 msgstr "Is 表达式"
 
-#: ../../language/fundamentals.md:1473
+#: ../../language/fundamentals.md:1474
 msgid ""
 "The `is` expression tests whether a value conforms to a specific pattern."
 " It returns a `Bool` value and can be used anywhere a boolean value is "
 "expected, for example:"
 msgstr "`is` 表达式测试值是否符合特定模式。它返回一个 `Bool` 值，并可以在期望布尔值的任何地方使用，例如："
 
-#: ../../language/fundamentals.md:1477
+#: ../../language/fundamentals.md:1478
 msgid ""
 "fn is_none[T](x : T?) -> Bool {\n"
 "  x is None\n"
@@ -18210,26 +18213,26 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1484
+#: ../../language/fundamentals.md:1485
 msgid ""
 "Pattern binders introduced by `is` expressions can be used in the "
 "following contexts:"
 msgstr "通过 `is` 表达式绑定的标识符可以在以下的上下文中使用："
 
-#: ../../language/fundamentals.md:1487
+#: ../../language/fundamentals.md:1488
 msgid ""
 "In boolean AND expressions (`&&`): binders introduced in the left-hand "
 "expression can be used in the right-hand expression"
 msgstr "在与表达式（`&&`）中：左侧表达式中绑定的标识符可以在右侧表达式中使用"
 
-#: ../../language/fundamentals.md:1491
+#: ../../language/fundamentals.md:1492
 msgid ""
 "fn f(x : Int?) -> Bool {\n"
 "  x is Some(v) && v >= 0\n"
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1498
+#: ../../language/fundamentals.md:1499
 msgid ""
 "In the first branch of `if` expression: if the condition is a sequence of"
 " boolean expressions `e1 && e2 && ...`, the binders introduced by the "
@@ -18239,7 +18242,7 @@ msgstr ""
 "在 `if` 的第一个分支中：如果条件是一系列布尔表达式 `e1 && e2 && ...`，则可以在条件为真的分支中使用 `is` "
 "表达式中绑定的标识符。"
 
-#: ../../language/fundamentals.md:1502
+#: ../../language/fundamentals.md:1503
 msgid ""
 "fn g(x : Array[Int?]) -> Unit {\n"
 "  if x is [v, .. rest] && v is Some(i) && i is 0..=10 {\n"
@@ -18250,11 +18253,11 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1509
+#: ../../language/fundamentals.md:1510
 msgid "In the following statements of a `guard` condition:"
 msgstr "下面举一个在 `guard` 中使用的情况："
 
-#: ../../language/fundamentals.md:1511
+#: ../../language/fundamentals.md:1512
 msgid ""
 "fn h(x : Int?) -> Unit {\n"
 "  guard x is Some(v) \n"
@@ -18262,11 +18265,11 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1518
+#: ../../language/fundamentals.md:1519
 msgid "In the body of a `while` loop:"
 msgstr "在 `while` 循环中的使用："
 
-#: ../../language/fundamentals.md:1520
+#: ../../language/fundamentals.md:1521
 msgid ""
 "fn i(x : Int?) -> Unit {\n"
 "  let mut m = x\n"
@@ -18277,14 +18280,14 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1527
+#: ../../language/fundamentals.md:1528
 msgid ""
 "Note that `is` expression can only take a simple pattern. If you need to "
 "use `as` to bind the pattern to a variable, you have to add parentheses. "
 "For example:"
 msgstr "`is` 表达式只能接受一个简单模式，如果你需要通过 `as` 把模式绑定到某个变量上，需要加括号。比如："
 
-#: ../../language/fundamentals.md:1530
+#: ../../language/fundamentals.md:1531
 msgid ""
 "fn j(x : Int) -> Int? {\n"
 "  Some(x)\n"
@@ -18297,11 +18300,11 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1537
+#: ../../language/fundamentals.md:1538
 msgid "Spread Operator"
 msgstr "展开运算符"
 
-#: ../../language/fundamentals.md:1539
+#: ../../language/fundamentals.md:1540
 msgid ""
 "MoonBit provides a spread operator to expand a sequence of elements when "
 "constructing `Array`, `String`, and `Bytes` using the array literal "
@@ -18312,11 +18315,11 @@ msgstr ""
 "MoonBit 提供了一个展开运算符，用于在使用数组字面量语法构造 `Array`、`String`和 `Bytes` "
 "时展开元素序列。要展开这样的序列，需要在其前面加上 `..` 前缀，并且该序列必须具有 `iter()` 方法，并且该方法能够产生相应类型的元素。"
 
-#: ../../language/fundamentals.md:1544
+#: ../../language/fundamentals.md:1545
 msgid "For example, we can use the spread operator to construct an array:"
 msgstr "例如，我们可以使用展开运算符构造一个数组："
 
-#: ../../language/fundamentals.md:1546
+#: ../../language/fundamentals.md:1547
 msgid ""
 "test {\n"
 "  let a1 : Array[Int] = [1, 2, 3]\n"
@@ -18327,11 +18330,11 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1553
+#: ../../language/fundamentals.md:1554
 msgid "Similarly, we can use the spread operator to construct a string:"
 msgstr "同样，我们可以使用展开运算符构造一个字符串："
 
-#: ../../language/fundamentals.md:1555
+#: ../../language/fundamentals.md:1556
 msgid ""
 "test {\n"
 "  let s1 : String = \"Hello\"\n"
@@ -18342,13 +18345,13 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1562
+#: ../../language/fundamentals.md:1563
 msgid ""
 "The last example shows how the spread operator can be used to construct a"
 " bytes sequence."
 msgstr "最后一个例子展示了如何使用展开运算符构造一个字节序列。"
 
-#: ../../language/fundamentals.md:1565
+#: ../../language/fundamentals.md:1566
 msgid ""
 "test {\n"
 "  let b1 : Bytes = \"hello\"\n"
@@ -18363,18 +18366,18 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/fundamentals.md:1573
+#: ../../language/fundamentals.md:1574
 msgid "TODO syntax"
 msgstr "TODO 语法"
 
-#: ../../language/fundamentals.md:1575
+#: ../../language/fundamentals.md:1576
 msgid ""
 "The `todo` syntax (`...`) is a special construct used to mark sections of"
 " code that are not yet implemented or are placeholders for future "
 "functionality. For example:"
 msgstr "`todo`语法 (`...`) 是一种特殊构造，用于标记尚未实现或用于未来功能的占位符代码段。例如："
 
-#: ../../language/fundamentals.md:1577
+#: ../../language/fundamentals.md:1578
 msgid ""
 "fn todo_in_func() -> Int {\n"
 "  ...\n"
@@ -20279,3 +20282,4 @@ msgid ""
 msgstr ""
 "黑盒测试文件（`_test.mbt`）导入当前包和包配置（`moon.pkg.json`）中的 `import` 和 `test-import` "
 "部分定义的包。"
+


### PR DESCRIPTION
fix wrong glossaries