### PR TITLE
docs: use ASCCI graph to explain scope

### DIFF
--- a/next/sources/language/src/is/top.mbt
+++ b/next/sources/language/src/is/top.mbt
@@ -10,33 +10,55 @@ fn start_with_lower_letter(s: String) -> Bool {
 
 // start is 2
 fn f(x : Int?) -> Bool {
+  //             scope
+  //           +--------+
+  //           |        |
   x is Some(v) && v >= 0
+  //        ^     ^ used
+  //        binder 
 }
 // end is 2
 
 // start is 3
 fn g(x : Array[Int?]) -> Unit {
-  if x is [v, .. rest] && v is Some(i) && i is 0..=10 {
-    println(v)
-    println(i)
-    println(rest)
+  //                             `v` and `rest` scope
+  //                   +---------------------------------------+
+  //                   |                  `i` scope            |
+  //                   |            +-----------------------+  | 
+  //                   |            |                       |  |
+  if x is [v, .. rest] && v is Some(i) && i is 0..=10 { //  |  |
+    //     ^     ^~~~     ^ used    ^     ^             //  |  |
+    //     binder binder            binder used         //  |  |
+    println(v)                                          //  |  |
+    //      ^ used                                      //  |  |
+    println(i)                                          //  |  |
+    //      ^ used                                      //  |  |
+    println(rest)                                       //  |  |
+    //      ^~~~ used                                   //  |  |
+    //                 ----------------------------------------+
   }
 }
 // end is 3
 
 // start is 4
 fn h(x : Int?) -> Unit {
-  guard x is Some(v) 
-  println(v)
+  guard x is Some(v)       // ------+
+  //              ^ binder //       |
+  println(v)               //       | scope
+  //      ^ used           //       |
+                           // ------+
 }
 // end is 4
 
 // start is 5
 fn i(x : Int?) -> Unit {
   let mut m = x
-  while m is Some(v) {
-    println(v)
-    m = None
+  while m is Some(v) {     // -----+
+    //            ^ binder //      |
+    println(v)             //      | scope
+    //      ^ used         //      |
+    m = None               //      |
+                           // -----+
   }
 }
 // end is 5


### PR DESCRIPTION
I refer to the way cppref explain `scope` to draw pictures in ascii.


Maybe inserting an image directly would be better than using an ASCII image.

![image](https://github.com/user-attachments/assets/d058877b-31e9-463b-a048-dfc56d3d6e34)
