### PR TITLE
docs: update may to can

### DIFF
--- a/next/language/ffi.md
+++ b/next/language/ffi.md
@@ -45,7 +45,7 @@ For Wasm backends, all functions interacting with outside world relies on the ho
 
 ``````{tab-item} JavaScript
 :sync: js
-JavaScript backend will generate a JavaScript file, which may be a CommonJS module, an ES module or an IIFE based on the [configuration](/toolchain/moon/package.md#js-backend-link-options).
+JavaScript backend will generate a JavaScript file, which can be a CommonJS module, an ES module or an IIFE based on the [configuration](/toolchain/moon/package.md#js-backend-link-options).
 ``````
 
 ```{tab-item} C

--- a/next/locales/zh_CN/LC_MESSAGES/language.po
+++ b/next/locales/zh_CN/LC_MESSAGES/language.po
@@ -13965,7 +13965,7 @@ msgid ""
 "CommonJS module, an ES module or an IIFE based on the "
 "[configuration](/toolchain/moon/package.md#js-backend-link-options)."
 msgstr ""
-"JavaScript 后端会生成一个 JavaScript 文件，这个文件可能是一个 CommonJS 模块、ES 模块或 IIFE，具体取决于 "
+"JavaScript 后端会生成一个 JavaScript 文件，这个文件可以是一个 CommonJS 模块、ES 模块或 IIFE，具体取决于 "
 "[配置](/toolchain/moon/package.md#js-backend-link-options)。"
 
 #: ../../language/ffi.md:53


### PR DESCRIPTION
# Documentation improvements

- Update `may be` to `can be`

## Difference

"Can be": is about ability, possibility, or general truth.

"May be": is about possibility, hypothetical situations, and permission requests.

> https://englishgrammarmaster.quora.com/What-is-the-difference-between-can-be-and-may-be-1