### PR TITLE
The word "is" can easily be confused with "ls" if its first letter is capitalized

### DIFF
--- a/next/language/fundamentals.md
+++ b/next/language/fundamentals.md
@@ -1486,7 +1486,7 @@ consecutive operations without the need to modify the return type of the methods
 :end-before: end operator 7
 ```
 
-### Is Expression
+### is Expression
 
 The `is` expression tests whether a value conforms to a specific pattern. It
 returns a `Bool` value and can be used anywhere a boolean value is expected,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d2f52dfe-6228-499c-b06f-d5b0c7253a06)
