### PR TITLE
添加NixOS的声明式MoonBit环境安装

### DIFF
--- a/next/tutorial/tour.md
+++ b/next/tutorial/tour.md
@@ -9,7 +9,6 @@ See [the General Introduction](../language/index.md) if you want to straight
 delve into the language.
 
 ## Installation
-
 **The extension**
 
 Currently, MoonBit development support is through the VS Code extension.
@@ -88,6 +87,58 @@ my-project
 
 In this tutorial, we will work with the `lib` mode project, and we assume the
 project name is `examine`.
+
+**NixOS**
+
+For NixOS users, you may want to install MoonBit and its plugins declaratively. Since MoonBit and its VS Code plugin have not yet been added to the official Nixpkgs, you can use a package from a community member's NUR (Nix User Repository) and use `nix-vscode-extensions` to install the plugin.
+
+In your `flake.nix`, add the following to the `inputs` attribute:
+
+```nix
+{
+  inputs = {
+    # ... your other inputs
+    moonbit = {
+      url = "github:DzmingLi/nur-packages";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    nix-vscode-extensions = {
+      url = "github:nix-community/nix-vscode-extensions";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    # ...
+  };
+}
+```
+
+In `configuration.nix` or any other system-level module, add the following to the `nixpkgs.overlays` option:
+
+```nix
+{
+  nixpkgs.overlays = [
+    # ... your other overlays
+    moonbit.overlays.default
+    nix-vscode-extensions.overlays.default
+    # ...
+  ];
+}
+```
+
+In your `home-manager` configuration, add the following to the `programs.vscode.profiles.default.extensions` list:
+
+```nix
+{
+  programs.vscode.profiles.default = {
+    # ...
+    extensions = with pkgs; [
+      # ... your other extensions
+      vscode-marketplace.moonbit.moonbit-lang
+      # ...
+    ];
+    # ...
+  };
+}
+```
 
 ## Example: Finding those who passed
 


### PR DESCRIPTION
为 NixOS 用户添加一份声明式的安装指南，用于配置 MoonBit 开发环境。
NixOS由于所有程序和库均放在/nix/store下且不可写，包需要经过patchelf，和对生成的包添加环境变量之类的操作。否则无法正常使用。而MoonBit无论是CLI还是VSCode插件都没有官方Nixpkgs。给NixOS用户使用MoonBit带来了困难。 我特地自己打了包并撰写了使用说明，经过测试可以正常使用，我会随着MoonBit的更新，自动更新我的打包。