### PR TITLE
fix: broken links in documentation

### DIFF
--- a/next/language/error_codes/E4151.md
+++ b/next/language/error_codes/E4151.md
@@ -1,6 +1,6 @@
 # E4151
 
-Values of type `FuncRef[T]` must be [closed](https://en.wikipedia.org/wiki/Lambda_calculus#Free_and_bound_variables) function.
+Values of type `FuncRef[T]` must be closed function -- it should not capture any local variables.
 
 MoonBit provides a builtin type `FuncRef[T]`, which represents closed function of type `T`.
 In MoonBit's native backend, `FuncRef[T]` corresponds to function pointer type,

--- a/next/language/ffi.md
+++ b/next/language/ffi.md
@@ -289,7 +289,7 @@ Sometimes, we want to pass a MoonBit function to the foreign interface as callba
 
 > A closure is the combination of a function bundled together (enclosed) with references to its surrounding state (the lexical environment). In other words, a closure gives a function access to its outer scope. In JavaScript, closures are created every time a function is created, at function creation time.
 
-In some cases, we would like to pass the callback function which doesn't capture any free variables. For this purpose, MoonBit provides a special type `FuncRef[T]`, which represents [closed](https://en.wikipedia.org/wiki/Lambda_calculus#Free_and_bound_variables) function of type `T`. Values of type `FuncRef[T]` must be closed function of type `T`, otherwise [a type error](/language/error_codes/E4151.md) would occur.
+In some cases, we would like to pass the callback function which doesn't capture any local free variables. For this purpose, MoonBit provides a special type `FuncRef[T]`, which represents closed function of type `T`. Values of type `FuncRef[T]` must be closed function of type `T`, otherwise [a type error](/language/error_codes/E4151.md) would occur.
 
 In other cases, a MoonBit function parameter would be represented as a function and an object containing the surrounding state.
 

--- a/next/tutorial/tour.md
+++ b/next/tutorial/tour.md
@@ -377,7 +377,7 @@ too.
    others to use.
 
 By default, the project will be shared under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.html), 
-which is a permissive license allowing everyone to use. You can also use other licenses, such as the [MulanPSL 2.0](https://license.coscl.org.cn/MulanPSL2),
+which is a permissive license allowing everyone to use. You can also use other licenses, such as the [MulanPSL 2.0](https://spdx.org/licenses/MulanPSL-2.0.html),
 by changing the field `license` in `moon.mod.json` and the content of `LICENSE`.
 
 ### Closing


### PR DESCRIPTION
- E4151.md: Remove broken Wikipedia anchor link, use plain text explanation
- ffi.md: Remove broken Wikipedia anchor link for closed function
- tour.md: Update MulanPSL 2.0 link to SPDX (old link had expired SSL cert)