### PR TITLE
feat: add MoonBit orientation skill

### DIFF
--- a/skills/moonbit-orientation/SKILL.md
+++ b/skills/moonbit-orientation/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: moonbit-orientation
+description: Use this skill when the user needs help solving MoonBit language, code, compiler diagnostic, package, toolchain, backend, FFI, test, or "does MoonBit have X?" questions. Use it even when MoonBit is only implied by .mbt files, moon.mod.json, moon.pkg.json, moon commands, wasm/js/native targets, or mooncakes packages. This skill helps choose the right MoonBit source of truth, discover APIs with moon ide, avoid stale assumptions, and validate fixes.
+---
+
+# MoonBit Orientation
+
+Use this skill to solve MoonBit developer questions by identifying the missing
+context first. This is an orientation skill, not a bundled copy of all MoonBit
+documentation.
+
+## Default workflow
+
+1. Classify the user's situation and likely missing layer.
+2. Check the gotchas below and the freshness gate before choosing a path.
+3. Load the smallest relevant reference file.
+4. If code, APIs, package config, or diagnostics are involved, inspect local
+   files or run the narrowest discovery command before answering.
+5. Give a practical answer: direct capability answer, MoonBit equivalent,
+   exact verification command or link, and narrow validation command when code
+   changed.
+6. If the final answer gives an exact API, import, error-code meaning, target
+   rule, or docs claim, include the command or URL that verifies it. Do this
+   even when the answer is short.
+
+If the user asks for exact standard-library APIs, package APIs, or recently
+changed behavior, verify with `moon ide doc`, official API docs, package docs,
+or local project files instead of guessing.
+
+## Freshness gate
+
+Some MoonBit facts move faster than model memory: new syntax, experimental
+features, package availability, package APIs, dependency versions, target
+support, and command flags. For these, do not turn memory into a final answer.
+
+Use this pattern:
+
+1. Say the capability-level answer if it is stable.
+2. State that exact APIs, package names, or tool behavior may have changed.
+3. Choose the current source: local project files, installed `moon` commands,
+   official docs, mooncakes package docs, or the registry.
+4. If the source cannot be checked in the current environment, say so and give
+   the next check. Do not present an unchecked package, import, function, flag,
+   or version as fact.
+
+This is not a rule to verify every stable fact. It is a rule to admit when
+MoonBit ecosystem or feature knowledge may be stale, then check the latest
+source before making exact claims.
+
+Keep freshness checks bounded. For package or API discovery, use one local
+toolchain query and, if needed, one registry or public-docs lookup. If those do
+not confirm the exact fact, stop and answer "not confirmed from the checked
+sources" with the next verification command. Do not run many near-duplicate web
+searches just to prove absence.
+
+Keep discovery narrow. Once a source-of-truth command or document answers the
+user's requested level of detail, stop searching unless the user asked for
+examples, signatures, alternatives, or validation by execution. Do not spend
+extra context proving nearby facts that are not needed for the answer.
+
+When recommending external material, provide a concrete URL from
+`references/source-map.md`. Do not assume the user has this repository checked
+out.
+
+## Gotchas
+
+- For standard-library and dependency APIs, default to `moon ide doc` in the
+  user's project. It reflects the installed toolchain and dependencies better
+  than memory or stale docs.
+- For ecosystem package availability, do not infer existence from a familiar
+  technology name. Check mooncakes or `moon add <candidate>` in a disposable or
+  user project before naming a dependency as available.
+- `llvm` is nightly-only. Stable backend guidance should use `wasm`, `wasm-gc`,
+  `js`, or `native`; `--target all` excludes `llvm`.
+- Do not answer exact API names by translating from Rust, Go, JavaScript, or
+  OCaml names. Discover the MoonBit API first.
+- Do not send users to "the docs" without a concrete URL or command.
+- Local `moon.mod.json` and `moon.pkg.json` beat generic advice for package
+  names, imports, targets, and dependencies.
+- For `E####` diagnostics, use `moon check --explain` or the exact online error
+  page pattern before inventing a cause.
+
+## Verification contract
+
+Treat MoonBit facts as three tiers:
+
+- **Stable capability facts**: language/toolchain shape covered by this skill,
+  such as no class-inheritance-first model, typed errors, common stable targets,
+  and `llvm` being nightly-only.
+- **Verified exact facts**: exact API names, signatures, package names, imports,
+  target config, and local project conventions confirmed by `moon ide`, local
+  files, generated interfaces, official docs, or mooncakes.
+- **Unverified guesses**: plausible API names or behavior inferred from another
+  language, memory, or naming convention.
+
+Never present unverified guesses as facts. If an exact fact is not verified,
+say what must be checked and provide the command or URL. Prefer "I can answer
+the capability, but the exact API needs `moon ide doc '*json*'`" over a
+plausible module or function name.
+
+If a verification command fails, returns no result, or was only checked outside
+the user's project, do not cite it as if it proved the exact API. Say what the
+failure means and give the next source, for example package installation,
+`moon tree`, mooncakes package docs, or a local dependency file.
+
+If you did verify an exact fact, say so compactly: "Verified with
+`moon ide doc '@json'`" or "Source: <URL>". Do not omit the verification source
+after naming exact imports, functions, or error meanings.
+
+Do not cite this skill's own reference files as the final verification source
+for users. The final answer should cite an external URL, a local project file,
+or a command result. The skill is guidance for the agent, not user-facing
+evidence.
+
+This rule still applies when a reference file contained the answer. Use the
+reference file to route the work, then cite the public URL, command, or local
+project file named by that reference.
+
+Avoid "likely" guesses for exact API behavior. For unknown calls such as
+`Json.parse` or `result.unwrap()`, say "verify whether this returns typed errors
+or a result-like value" instead of guessing which one it uses.
+
+## Situation routing
+
+- Learning MoonBit or asking where to start: read `references/question-routing.md`
+  and `references/source-map.md`.
+- Asking "Does MoonBit have X?", API availability, or quick capability
+  questions: read `references/answer-shapes.md` first. Load
+  `references/capabilities-faq.md` only when the quick shape does not cover the
+  concept or the user asks for a broader comparison. If exact APIs are involved,
+  use `references/lookup-recipes.md`.
+- Coming from Go, Rust, TypeScript, OCaml, or another language: read
+  `references/mental-models.md`.
+- Writing, reviewing, or refactoring MoonBit code: read `references/idioms.md`.
+- Debugging compiler output, `moon` output, package errors, backend errors, or
+  diagnostics with an `E####` code: read `references/diagnostics-playbook.md`
+  and the relevant recipe in `references/lookup-recipes.md`.
+- Setting up modules, packages, workspaces, tests, docs, coverage, or build
+  targets: read `references/toolchain-map.md`.
+- Choosing between official docs, mooncakes API docs, the Tour, examples, error
+  code docs, or local project inspection: read `references/source-map.md`.
+
+For tasks that span multiple areas, read the most specific reference first, then
+one secondary reference if needed.
+
+## Missing-layer checklist
+
+Before answering, decide whether the unknown is most likely:
+
+- language semantics
+- MoonBit idiom or style
+- toolchain behavior
+- package, dependency, or standard-library API
+- backend limitation or target-specific behavior
+- official docs, examples, or error-code reference
+- project-local convention
+
+State uncertainty briefly when it matters, but do not stop at uncertainty if a
+recipe can resolve it. For concrete code work, prefer a narrow validation
+command such as `moon check`, `moon test`, or `moon build` with the relevant
+`--target`.
+
+## Boundaries
+
+- Do not pretend this skill contains the full language specification.
+- Do not provide exact standard-library signatures unless they were verified.
+- Do not use this skill for maintaining the `moonbit-docs` repository itself;
+  use the repo maintainer skill for docs, translation, Sphinx, or example
+  maintenance workflows.
+- Keep answers practical: show the next source to check, the likely fix, and the
+  narrow command that would validate it.

--- a/skills/moonbit-orientation/agents/openai.yaml
+++ b/skills/moonbit-orientation/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "MoonBit Orientation"
+  short_description: "Find the right MoonBit docs and fixes"
+  default_prompt: "Use $moonbit-orientation to diagnose this MoonBit question and choose the right docs or checks before answering."
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/moonbit-orientation/references/answer-shapes.md
+++ b/skills/moonbit-orientation/references/answer-shapes.md
@@ -1,0 +1,115 @@
+# Answer Shapes
+
+Use this file first for "Does MoonBit have X?", API availability, and quick
+capability questions. Load larger references only if this file does not cover
+the needed concept.
+
+## Capability Question Shape
+
+Answer in this order:
+
+1. **Short answer**: yes, no, or yes-with-caveat.
+2. **MoonBit equivalent**: the MoonBit model or idiom the user should use.
+3. **When to verify**: say whether exact APIs, imports, signatures, target
+   behavior, or package names need local verification.
+4. **Command or link**: give one concrete command or public URL.
+
+Do not end with a vague "check the docs." If exact names were not verified, say
+that plainly and give the lookup command.
+
+Never cite this skill's files as the user's final source. Final evidence must be
+a command the agent ran or recommends, a public URL, or a local project file
+that belongs to the user's codebase.
+
+## API Availability Shape
+
+For standard-library or package API questions:
+
+1. Give the capability-level answer if stable.
+2. Say when model memory may be stale because the feature, package, or API is
+   new, experimental, third-party, or target-specific.
+3. Prefer `moon ide doc` in the user's project for exact APIs.
+4. For package availability, check mooncakes or a real `moon add <candidate>`
+   result before saying a package exists.
+5. If a local project is unavailable, use <https://mooncakes.io/docs/moonbitlang/core/>
+   or <https://mooncakes.io/>.
+6. Do not name exact imports, function signatures, or method behavior unless
+   verified by command output, local files, or public API docs.
+
+Spend at most one local API query and one registry/docs lookup before answering
+at capability level. Repeated searches with the same keyword in different forms
+usually waste context; say what was not confirmed and give the next check.
+
+Useful first commands:
+
+- `moon ide doc '*json*'` for JSON-like APIs.
+- `moon ide doc ''` for available packages or current package symbols.
+- `moon ide doc 'String::*find*'` for string methods.
+- `moon ide doc 'Array::*map*'` for array methods.
+
+Stop after the first successful source that answers the user's requested level
+of detail. Do not inspect functions, examples, or call sites unless the user
+asked for signatures, usage, code review, or validation.
+
+## Common Stable Answers
+
+- **Inheritance**: MoonBit does not use class inheritance as the primary model.
+  Use structs/enums, methods, traits, composition, and pattern matching. Source:
+  <https://docs.moonbitlang.com/en/latest/language/methods.html>.
+- **Traits/interfaces**: MoonBit has traits for ad-hoc polymorphism and
+  overloading. Do not import Rust lifetime/ownership assumptions or Go
+  structural-interface assumptions. Source:
+  <https://docs.moonbitlang.com/en/latest/language/methods.html>.
+- **Exceptions**: MoonBit has typed error effects with `raise`, `try`, `catch`,
+  and `noraise`, not unchecked JavaScript-style exceptions. Source:
+  <https://docs.moonbitlang.com/en/latest/language/error-handling.html>.
+- **Null**: Do not model ordinary MoonBit code around implicit nullable
+  references. Use explicit absence in the type model, then verify exact
+  option-like APIs with `moon ide doc`.
+- **JSON support**: answer at capability level, then verify exact package/API
+  names with `moon ide doc '*json*'` or mooncakes. If you name an import or
+  function, state the command or URL that verified it.
+- **LLVM**: `llvm` is nightly-only. Stable/common targets are `wasm`,
+  `wasm-gc`, `js`, and `native`; `--target all` excludes `llvm`. Do not invent
+  target configuration syntax for combining stable targets with `llvm`; point
+  to the target configuration docs:
+  <https://docs.moonbitlang.com/en/latest/toolchain/moon/package.html> and
+  <https://docs.moonbitlang.com/en/latest/toolchain/moon/module.html>.
+- **New syntax**: verify against official docs or local examples before
+  answering from memory. New syntax is high-risk for stale model knowledge.
+- **Experimental or ecosystem features**: give the current capability only at
+  the level you can support. For exact packages, versions, imports, APIs, or
+  backend support, say model knowledge may be stale and verify with installed
+  `moon` commands, official docs, mooncakes, or local dependency files.
+
+## Unknown Ecosystem Package Shape
+
+Use this for questions such as "is there a MoonBit package for Lottie?" or
+"what should I import for <ecosystem library>?"
+
+1. **Short answer**: say whether it is a known built-in capability, a verified
+   package, not found from checked sources, or unknown because it was not
+   checked.
+2. **MoonBit equivalent**: use the closest stable route, such as stdlib API,
+   mooncakes package, FFI/interop, or implementing a small wrapper.
+3. **Freshness note**: say package availability can change and exact dependency
+   names must come from current registry or project files.
+4. **Command or link**: give one concrete verification path, such as
+   `moon update` plus `moon add <candidate>`, `moon ide doc '*keyword*'`, or
+   <https://mooncakes.io/>.
+
+Do not say "there is no package" unless a current registry or public search was
+actually checked. Prefer "I cannot confirm a package from the available
+sources; verify on mooncakes before choosing an import" when the check is
+incomplete.
+
+For absence claims, avoid exhaustive searching. One relevant local search and
+one registry/docs search are enough to justify "not confirmed from the checked
+sources"; the user can perform the live registry check if the environment cannot.
+
+## If More Detail Is Needed
+
+- Language capability comparisons: load `capabilities-faq.md`.
+- Exact API lookup procedure: load `lookup-recipes.md`.
+- Coming from another language: load `mental-models.md`.
+- Toolchain, package, workspace, or backend setup: load `toolchain-map.md`.

--- a/skills/moonbit-orientation/references/capabilities-faq.md
+++ b/skills/moonbit-orientation/references/capabilities-faq.md
@@ -1,0 +1,179 @@
+# Capabilities FAQ
+
+Use this file for capability-level answers. If the user asks for exact module
+names, function names, signatures, or package behavior, verify with `moon ide
+doc`, official API docs, or the local project.
+
+## Answering rule
+
+For capability questions, do not merely say "check the docs." Give the stable
+capability answer first, then the MoonBit model, then the exact command or link
+to verify details. If you name an exact API, import, function, or error meaning,
+also name the command or URL used to verify it.
+
+## Language model
+
+- MoonBit has algebraic data types, pattern matching, structs, enums, methods,
+  traits, generics, labelled arguments, optional arguments, and derive support.
+- MoonBit does not use class inheritance as its main abstraction model. Explain
+  code in terms of data types, methods, traits, composition, and pattern
+  matching.
+- MoonBit methods are associated with types. Method definitions normally belong
+  with the type's package; private local methods can extend foreign types in
+  limited cases.
+- MoonBit traits are for ad-hoc polymorphism and overloading. They are closer to
+  typeclass-style constraints than to subclass inheritance.
+- MoonBit supports operator overloading through built-in traits and selected
+  method aliases.
+
+Common direct answers:
+
+- **Does MoonBit have inheritance?** Not class inheritance as the primary model.
+  Use structs/enums for data, methods for attached behavior, traits for shared
+  operations, and composition or pattern matching for variation. Source:
+  <https://docs.moonbitlang.com/en/latest/language/methods.html>.
+- **Does MoonBit have traits/interfaces?** It has traits for ad-hoc
+  polymorphism and overloading. Do not assume Rust lifetime rules or Go
+  structural interfaces. Source:
+  <https://docs.moonbitlang.com/en/latest/language/methods.html>.
+- **Does MoonBit have generics?** Yes. Verify exact syntax in the language docs
+  if writing examples:
+  <https://docs.moonbitlang.com/en/latest/language/fundamentals.html>.
+- **Does MoonBit have pattern matching?** Yes, and it is a normal way to work
+  with enums and structured data. Start at
+  <https://docs.moonbitlang.com/en/latest/language/fundamentals.html>.
+
+## Error handling
+
+- MoonBit has typed error handling with `raise`, `try`, `catch`, and `noraise`.
+- Use `raise?` for error-polymorphic higher-order functions.
+- `fail` is the usual convenience for unrecoverable failures with source
+  location context.
+- Do not describe MoonBit errors as JavaScript-like unchecked exceptions; the
+  effect is represented in function signatures.
+
+Common direct answers:
+
+- **Does MoonBit have exceptions?** It has typed error effects, not unchecked
+  exceptions. Explain `raise`, `try`, `catch`, and `noraise`. Source:
+  <https://docs.moonbitlang.com/en/latest/language/error-handling.html>.
+- **Does MoonBit have Result?** Do not assume the exact stdlib API name. First
+  decide whether local code uses typed errors or explicit result-like values,
+  then verify APIs with `moon ide doc '*result*'`.
+
+## Nullability and optional data
+
+- Do not assume nullable references by default.
+- Model absence with the appropriate option-like type or domain-specific enum.
+- Check `moon ide doc` or the standard library docs
+  (<https://mooncakes.io/docs/moonbitlang/core/>) for exact option/result APIs
+  before naming functions.
+
+Common direct answers:
+
+- **Does MoonBit have null?** Do not model normal MoonBit code around implicit
+  nullable references. Use explicit absence in the type model and verify the
+  exact option-like API with `moon ide doc '*option*'`.
+
+## Tooling
+
+- MoonBit has a `moon` build system with commands for creating modules, checking,
+  building, running, testing, formatting, docs, dependencies, benchmarks, and
+  coverage.
+- MoonBit has modules, packages, and workspaces. Use local `moon.mod.json` and
+  `moon.pkg.json` files as the source of truth for a project.
+- MoonBit has IDE support, including VSCode support and `moon ide`.
+- MoonBit has package registry and API documentation at <https://mooncakes.io/>.
+
+Common direct answers:
+
+- **How do I find an API?** Prefer `moon ide doc` in the user's project, then
+  mooncakes if local lookup is unavailable.
+- **How do I inspect local code?** Prefer `moon ide outline`, `moon ide
+  peek-def`, and `moon ide find-references` over plain text search when symbol
+  precision matters.
+- **How do I validate code?** Use `moon check` for compile/type feedback and
+  `moon test` for behavior.
+
+## Backends and interop
+
+- MoonBit's stable/common targets are `wasm`, `wasm-gc`, `js`, and `native`.
+- `llvm` is only for nightly toolchains. Do not present it as a normal stable
+  target, and do not recommend it unless the user is explicitly using nightly.
+- `--target all` expands to `wasm`, `wasm-gc`, `js`, and `native`; it does not
+  include `llvm`.
+- Backend behavior can matter. Confirm the selected `--target` before debugging
+  target-specific output.
+- MoonBit supports FFI and WebAssembly workflows, but exact boundary code is
+  backend-specific and should be verified against the FFI docs
+  (<https://docs.moonbitlang.com/en/latest/language/ffi.html>) or WebAssembly
+  toolchain docs (<https://docs.moonbitlang.com/en/latest/toolchain/wasm/index.html>).
+
+Common direct answers:
+
+- **Does MoonBit support LLVM?** Only with nightly toolchains. Do not recommend
+  it for stable users.
+- **Does `--target all` include LLVM?** No. It covers `wasm`, `wasm-gc`, `js`,
+  and `native`.
+- **Can one module mix backends?** MoonBit supports target configuration such as
+  `preferred-target`, `supported-targets`, and package-level target settings.
+  Verify the project config and target docs.
+
+## Standard library and packages
+
+- This skill does not bundle the full standard library.
+- For "is there a JSON/string/array/map/etc. API?", answer at capability level
+  first, then verify exact names with the installed toolchain.
+- Prefer `moon ide doc` for the current local project and current installed
+  MoonBit toolchain. Its documentation page may lag the CLI, so prefer command
+  output over memory when available.
+- Useful `moon ide doc` queries:
+  - `moon ide doc ''`: list available packages or current package symbols.
+  - `moon ide doc '@json'`: inspect an available package.
+  - `moon ide doc '*parse*'`: search symbols by wildcard.
+  - `moon ide doc 'String::*rev*'`: search methods on a type.
+  - `moon ide doc '@pkg.Type::member'`: inspect a specific member.
+- Use mooncakes.io and package docs when `moon ide doc` is unavailable, when the
+  package is not installed locally, or when the user needs a browsable external
+  source:
+  - Standard library: <https://mooncakes.io/docs/moonbitlang/core/>
+  - Package registry: <https://mooncakes.io/>
+- For third-party packages, inspect local dependency declarations before
+  suggesting an import or exact package name.
+
+Common direct answers:
+
+- **Does MoonBit have JSON support?** Do not answer with an unverified module
+  name. In a project, run `moon ide doc '*json*'`; otherwise check
+  <https://mooncakes.io/>. If you provide an import such as `@json`, state
+  exactly where it was verified.
+- **Does MoonBit have string/array/map APIs?** Yes at the capability level, but
+  verify exact methods with queries like `moon ide doc 'String::*find*'` or
+  `moon ide doc 'Array::*map*'`.
+- **How do I know what packages are available?** Run `moon ide doc ''` in the
+  project or search <https://mooncakes.io/>.
+
+## Experimental or moving areas
+
+- Async exists but should be treated as experimental unless current docs say
+  otherwise. Check <https://docs.moonbitlang.com/en/latest/language/async-experimental.html>.
+- Verification and some advanced tooling are specialized. Prefer official docs
+  (<https://docs.moonbitlang.com/en/latest/language/verification.html>) and
+  local validation over memory.
+
+## New syntax features
+
+- Treat new MoonBit syntax as high-risk for stale model memory. Verify against
+  official docs or local examples before answering.
+- For regex, new code should prefer regex match expression `=~`; `lexmatch` and
+  `lexmatch?` are deprecated. Sources:
+  - <https://docs.moonbitlang.com/en/latest/language/fundamentals.html#regex-match-expression>
+  - <https://docs.moonbitlang.com/en/latest/language/fundamentals.html#lexmatch>
+- Regex literals use `re"..."`. Named regex capture groups such as
+  `(?<id>...)` are capture metadata, not MoonBit binders; use `as` in `=~` to
+  bind matched text.
+- In `=~`, use `before` and `after` to bind unmatched prefix/suffix as
+  `StringView`.
+- `\b` and `\B` work when a regex literal is used as a first-class `Regex`
+  value, but are not currently available in `=~` constant contexts.
+- To match a literal `{`, use `[{]` rather than `\{`.

--- a/skills/moonbit-orientation/references/diagnostics-playbook.md
+++ b/skills/moonbit-orientation/references/diagnostics-playbook.md
@@ -1,0 +1,73 @@
+# Diagnostics Playbook
+
+Use this file before fixing compiler, package, test, or backend failures.
+
+## First pass
+
+1. Preserve the exact command, target, working directory, and diagnostic text.
+2. Identify whether the failure comes from `moonc`, `moon`, tests, dependency
+   resolution, generated docs, or backend output.
+3. Fix the earliest root-cause diagnostic first; later diagnostics may cascade.
+4. Inspect local `moon.mod.json`, `moon.pkg.json`, imports, and touched files.
+5. Re-run the narrowest command that reproduces the failure.
+
+## Error codes
+
+- If the diagnostic includes `E####`, consult the exact error-code docs when
+  available.
+- Use `moon check --explain` when available.
+- Use the online error index at
+  <https://docs.moonbitlang.com/en/latest/language/error_codes/index.html>.
+- For a specific code, use the URL pattern
+  `https://docs.moonbitlang.com/en/latest/language/error_codes/E####.html`,
+  for example
+  <https://docs.moonbitlang.com/en/latest/language/error_codes/E0020.html>.
+- If you state what an error code means, include the exact `moon check
+  --explain` result or the exact error-code URL in the answer.
+- Do not assume every error code has a complete runnable example yet.
+
+## Type and method errors
+
+- Check whether the receiver type is the type the method belongs to.
+- Check whether a trait implementation is required or imported.
+- Check visibility and package boundaries before adding duplicate helpers.
+- Avoid defining public methods for foreign types outside the type's package;
+  local private methods have narrower use.
+
+## Package and dependency errors
+
+- Inspect module-level dependencies in `moon.mod.json`.
+- Inspect package imports and backend settings in `moon.pkg.json`.
+- Use `moon tree`, `moon add`, `moon remove`, `moon install`, or `moon update`
+  only after confirming the intended dependency change.
+- If generated interfaces are stale, `moon info` can help inspect public APIs.
+
+## Test failures
+
+- Determine whether the failure is a compile error, assertion failure, snapshot
+  change, backend mismatch, or missing test dependency.
+- Prefer `moon test` for the affected package before broader test runs.
+- When tests are target-sensitive, include the relevant `--target`.
+
+## Backend errors
+
+- Confirm the selected target: `wasm`, `wasm-gc`, `js`, or `native`.
+- Treat `llvm` as nightly-only. If a failure mentions `llvm`, first confirm the
+  user is on a nightly toolchain and actually intended to use it.
+- Backend-specific interop and output layout should be checked against the
+  relevant official docs:
+  - FFI: <https://docs.moonbitlang.com/en/latest/language/ffi.html>
+  - WebAssembly: <https://docs.moonbitlang.com/en/latest/toolchain/wasm/index.html>
+- If code works on one target but not another, inspect backend conditionals,
+  package config, FFI declarations, and unsupported APIs.
+
+## Validation commands
+
+- `moon check`: fast compile/type feedback.
+- `moon check --target all`: broad target compatibility when supported by the
+  project; this does not include `llvm`.
+- `moon test`: package or module test validation.
+- `moon build --target <target>`: backend-specific build validation.
+- `moon info`: generated public interface inspection.
+- `moon ide doc '<query>'`: verify available APIs before changing imports or
+  calls.

--- a/skills/moonbit-orientation/references/idioms.md
+++ b/skills/moonbit-orientation/references/idioms.md
@@ -1,0 +1,71 @@
+# Idioms
+
+Use this file for code generation, review, and refactoring. Keep guidance
+practical and verify project-local conventions before changing code.
+
+## General style
+
+- Prefer clear data modeling with structs, enums, and pattern matching.
+- Use methods for behavior naturally attached to a type.
+- Use traits for shared operations and ad-hoc polymorphism, not as class
+  inheritance.
+- Prefer small direct code over abstractions that hide only a few lines.
+- Preserve the style of the surrounding package.
+
+## Package-aware code
+
+- Check package boundaries before adding public definitions.
+- Avoid duplicating a helper if a local package already exposes the concept.
+- Do not invent imports or dependency names. Inspect `moon.pkg.json` and API
+  docs.
+- When adding public APIs, consider whether `moon info` should be run to inspect
+  the exposed interface.
+
+## Error handling
+
+- Use MoonBit's typed error model when the surrounding code uses `raise`,
+  `try`, `catch`, or `noraise`.
+- Do not translate every error into an option-like value unless that is the
+  local pattern.
+- For unrecoverable failures, prefer the project's existing failure style; the
+  standard `fail` helper is common in examples.
+
+## Tests
+
+- Add or update focused tests for behavior changes.
+- Use `moon test` for behavior and `moon check` for type-level validation.
+- If the package is target-sensitive, validate the relevant target explicitly.
+
+## Formatting
+
+- Use `moon fmt` intentionally and narrowly in existing projects.
+- Avoid formatting unrelated files while answering a small question.
+- If the user only asked for explanation or review, do not rewrite code.
+
+## API uncertainty
+
+- If a solution depends on a standard-library function name or signature, verify
+  it with `moon ide doc`, mooncakes API docs
+  (<https://mooncakes.io/docs/moonbitlang/core/>), or local generated
+  interfaces.
+- It is better to say which API needs checking than to provide a plausible but
+  unverified name.
+
+When reviewing code with unknown APIs, separate API verification from style
+judgment. For example, for code that calls `Json.parse` and `result.unwrap()`,
+do not assume either API exists. First suggest `moon ide doc '*json*'`,
+`moon ide doc '@json'`, and `moon ide doc '*result*'`; then review whether the
+verified API matches the project's error-handling style.
+
+Do not say an unknown API "likely" returns typed errors, a `Result`, an option,
+or any other shape. Phrase it conditionally: "If `Json.parse` raises, use
+`try`/`catch`; if it returns a result-like value, verify whether `unwrap` exists
+or prefer explicit handling."
+
+## Review posture
+
+- Lead with correctness, diagnostics, target behavior, tests, and project
+  conventions.
+- Call out when the code looks like it imported assumptions from another
+  language.
+- Suggest the smallest change that makes the code idiomatic and verifiable.

--- a/skills/moonbit-orientation/references/lookup-recipes.md
+++ b/skills/moonbit-orientation/references/lookup-recipes.md
@@ -1,0 +1,129 @@
+# Lookup Recipes
+
+Use these recipes when a question needs facts that can drift with toolchain,
+dependencies, package configuration, or backend.
+
+## Standard library or dependency API
+
+Default to the installed toolchain first.
+
+1. If inside a MoonBit project, run `moon ide doc ''` to see available packages
+   or current package symbols.
+2. Search by likely concept with wildcards, for example:
+   - `moon ide doc '*json*'`
+   - `moon ide doc '*parse*'`
+   - `moon ide doc 'String::*find*'`
+   - `moon ide doc 'Array::*map*'`
+3. If a package is found, inspect it with `moon ide doc '@pkg'`.
+4. If a type is found, inspect methods with `moon ide doc 'Type'` or
+   `moon ide doc '@pkg.Type::member'`.
+5. If `moon ide doc` is unavailable or the package is not installed, use:
+   - Standard library: <https://mooncakes.io/docs/moonbitlang/core/>
+   - Package registry: <https://mooncakes.io/>
+
+Answer with the verified API only if you can also state how it was verified.
+If no API is verified, say what should be checked and give the most likely next
+query rather than inventing a name.
+
+If a query returns no results, treat that as "not found in this context", not
+as proof that the API does not exist anywhere. Check whether the package is
+installed, whether dependencies are fetched, and whether mooncakes or official
+docs have newer information.
+
+Stop after the first successful query that answers the user's exact need. For a
+capability-plus-import question, a package query such as `moon ide doc '*json*'`
+or `moon ide doc '@pkg'` is usually enough. Only inspect individual functions,
+types, examples, or call sites when the user asks for signatures, usage, or code
+review.
+
+## Ecosystem package availability
+
+Use this when the user asks whether MoonBit has a package, binding, framework,
+or integration for another ecosystem concept.
+
+1. Name any stable built-in capability only if it is covered by official docs or
+   the installed toolchain.
+2. Search the current registry or package docs, usually <https://mooncakes.io/>.
+3. If there is a plausible candidate, verify it in a project with
+   `moon update`, `moon add <candidate>`, `moon tree`, and
+   `moon ide doc '<keyword>'` or `moon ide doc '@pkg'`.
+4. If no candidate is confirmed, say that package availability may have changed
+   and give the registry keywords to check. Do not invent `moonbitlang/<name>`
+   or `@<name>` imports from the concept name.
+5. If the practical answer is interop, route to FFI or target-specific docs
+   instead of pretending a native package exists.
+
+Budget this lookup tightly. Use one local query such as
+`moon ide doc '*keyword*'`, then one registry/docs lookup. If neither confirms a
+package, answer with "not confirmed from the checked sources" and the exact
+next command or URL. Do not keep trying many search spellings unless the user
+explicitly asks for a package hunt.
+
+Useful links:
+
+- Package registry: <https://mooncakes.io/>
+- Package workflow:
+  <https://docs.moonbitlang.com/en/latest/toolchain/moon/package-manage-tour.html>
+- FFI: <https://docs.moonbitlang.com/en/latest/language/ffi.html>
+
+## "Does MoonBit have X?"
+
+1. Answer the capability directly from `capabilities-faq.md` if it is listed
+   there.
+2. Give the MoonBit model or equivalent concept.
+3. If the question depends on exact APIs, run the API recipe above.
+4. Include a concrete verification command or link.
+5. If you name an exact import, function, or target rule, include the verification
+   command or URL in the final answer.
+
+Common examples:
+
+- Inheritance: no class inheritance as the main model; use data types, methods,
+  traits, composition, and pattern matching.
+- Exceptions: typed error effects with `raise`, `try`, `catch`, and `noraise`,
+  not unchecked exceptions.
+- Null: do not assume nullable references; model absence explicitly.
+- JSON or package APIs: first try `moon ide doc '*json*'`, then mooncakes.
+- Async: exists but is experimental; verify against
+  <https://docs.moonbitlang.com/en/latest/language/async-experimental.html>.
+
+## Compiler error code
+
+1. Preserve the exact command, working directory, target, file, and diagnostic.
+2. Run or suggest `moon check --explain` when available.
+3. For `E####`, use:
+   `https://docs.moonbitlang.com/en/latest/language/error_codes/E####.html`
+4. Fix the first root-cause diagnostic before cascaded diagnostics.
+5. Validate with the smallest reproducing command, usually `moon check`,
+   `moon test`, or `moon build --target <target>`.
+6. If you state the code's meaning, cite the exact error URL or command result.
+
+## Backend or target behavior
+
+1. Inspect `moon.mod.json` for `preferred-target` and `supported-targets`.
+2. Inspect `moon.pkg.json` for package-level targets, imports, and backend
+   conditions.
+3. Treat stable targets as `wasm`, `wasm-gc`, `js`, and `native`.
+4. Treat `llvm` as nightly-only; do not recommend it unless the user is
+   explicitly on nightly.
+5. Use:
+   - Package targets:
+     <https://docs.moonbitlang.com/en/latest/toolchain/moon/package.html>
+   - Module targets:
+     <https://docs.moonbitlang.com/en/latest/toolchain/moon/module.html>
+   - WebAssembly:
+     <https://docs.moonbitlang.com/en/latest/toolchain/wasm/index.html>
+   - FFI: <https://docs.moonbitlang.com/en/latest/language/ffi.html>
+6. In the final answer, cite one of these public URLs or a local config file
+   path. Do not cite this skill's reference files as evidence.
+
+## Project layout or package configuration
+
+1. Find `moon.mod.json` to identify the module root.
+2. Find relevant `moon.pkg.json` files for package imports and targets.
+3. Use `moon ide outline <file-or-directory>` to inspect structure before broad
+   edits.
+4. Use `moon ide peek-def <symbol>` before changing calls to unfamiliar local
+   APIs.
+5. Use `moon ide find-references <symbol>` before renaming or changing public
+   behavior.

--- a/skills/moonbit-orientation/references/mental-models.md
+++ b/skills/moonbit-orientation/references/mental-models.md
@@ -1,0 +1,60 @@
+# Mental Models
+
+Use this file when the user brings assumptions from another language. Keep the
+comparison short, then show the MoonBit way.
+
+## From Go
+
+- Think modules and packages, but inspect `moon.mod.json` and `moon.pkg.json`
+  instead of assuming Go module layout.
+- Prefer explicit data types plus functions, methods, and traits over interface
+  substitution patterns copied from Go.
+- Error handling is typed with `raise`/`try`/`catch`, not `if err != nil`.
+- Use `moon check` for fast feedback before deeper builds.
+
+## From Rust
+
+- Traits exist, but do not assume Rust's ownership, borrowing, lifetimes, or
+  orphan-rule details apply.
+- Pattern matching and algebraic data types are natural tools.
+- When you want `Result`-style APIs, first check whether the codebase expects
+  MoonBit typed errors with `raise` or explicit result-like values.
+- Verify exact stdlib names instead of translating Rust method names directly.
+
+## From TypeScript or JavaScript
+
+- Do not model everything with dictionaries, nullable objects, or dynamic
+  shapes. Prefer explicit MoonBit types.
+- Backend `js` exists, but MoonBit source is statically typed and compiled.
+- For interop, confirm whether the target is `js`, `wasm`, `wasm-gc`, or
+  `native`.
+- For backend and FFI details, use the FFI docs
+  (<https://docs.moonbitlang.com/en/latest/language/ffi.html>) and WebAssembly
+  docs (<https://docs.moonbitlang.com/en/latest/toolchain/wasm/index.html>).
+- Avoid inventing npm-like workflows; MoonBit project behavior lives in `moon`
+  config and commands.
+
+## From OCaml or ML-family languages
+
+- Algebraic data types and pattern matching are a useful starting point.
+- MoonBit has its own package, method, trait, and toolchain model; do not assume
+  OCaml module semantics.
+- Check MoonBit syntax for labelled arguments, optional arguments, methods, and
+  error effects rather than translating directly.
+
+## From object-oriented languages
+
+- Do not look for class inheritance first.
+- Model the domain with structs/enums, attach behavior with methods, and abstract
+  shared operations with traits.
+- Use composition and pattern matching where subclass hierarchies would be used
+  elsewhere.
+
+## From C/C++ or systems languages
+
+- Confirm the backend and interop boundary early.
+- Do not assume pointer-level control unless the docs for the selected backend
+  and FFI path provide it:
+  <https://docs.moonbitlang.com/en/latest/language/ffi.html>.
+- Prefer MoonBit data modeling and standard library abstractions until lower
+  level interop is required.

--- a/skills/moonbit-orientation/references/question-routing.md
+++ b/skills/moonbit-orientation/references/question-routing.md
@@ -1,0 +1,77 @@
+# Question Routing
+
+Start with the user's task shape, not with a memorized answer.
+
+## Learning or onboarding
+
+Use this route when the user asks how to learn MoonBit, where to start, or how a
+concept works.
+
+- If they are brand new, point to the interactive Tour
+  (<https://tour.moonbitlang.com/>) or the Native CLI Quickstart
+  (<https://docs.moonbitlang.com/en/latest/tutorial/cli-quickstart.html>)
+  before deep language pages.
+- If they know another language, load `mental-models.md`.
+- If they need a project, load `toolchain-map.md`.
+- Prefer small runnable examples over broad summaries.
+
+## Writing or reviewing code
+
+Use this route when the user provides MoonBit code or asks for idiomatic code.
+
+- Inspect nearby project files before assuming package names, visibility, or
+  dependencies.
+- Load `idioms.md` for stable style guidance.
+- If unfamiliar symbols or APIs are involved, use `lookup-recipes.md` before
+  editing.
+- Check whether the issue is semantic, API-specific, or project-local.
+- Validate with `moon check` or `moon test` when feasible.
+
+## Debugging diagnostics
+
+Use this route when the user provides compiler output, `moon` output, failing
+tests, package errors, or an `E####` code.
+
+- Load `diagnostics-playbook.md`.
+- Preserve the exact diagnostic text and location.
+- If an error code appears, consult exact error-code docs when available. The
+  online index is
+  <https://docs.moonbitlang.com/en/latest/language/error_codes/index.html>.
+- Fix the first root-cause diagnostic before chasing cascaded errors.
+
+## Project or toolchain setup
+
+Use this route for modules, packages, workspaces, dependencies, tests, docs,
+coverage, build targets, and publishing.
+
+- Load `toolchain-map.md`.
+- Use `lookup-recipes.md` for backend, package, and project-layout checks.
+- Inspect `moon.mod.json`, `moon.pkg.json`, and workspace layout if local files
+  exist.
+- Distinguish module-level, package-level, and workspace-level configuration.
+
+## Capability questions
+
+Use this route for "Does MoonBit have X?", "Can MoonBit do Y?", or "What is the
+MoonBit equivalent of Z?"
+
+- Load `answer-shapes.md` first.
+- Answer at capability level first.
+- For exact APIs, route to `moon ide doc`, standard-library docs
+  (<https://mooncakes.io/docs/moonbitlang/core/>), or the package registry
+  (<https://mooncakes.io/>).
+- For target-specific behavior, also load `toolchain-map.md` or `source-map.md`.
+- Load `capabilities-faq.md` only when the quick answer shape does not cover the
+  concept or the user asks for a broader comparison.
+
+## Choosing sources
+
+Use this route when the agent is unsure where truth lives.
+
+- Load `source-map.md`.
+- Prefer local project files for project-specific behavior.
+- Prefer official docs (<https://docs.moonbitlang.com/en/latest/>) for language
+  and toolchain concepts.
+- Prefer `moon ide doc` or mooncakes API docs
+  (<https://mooncakes.io/docs/moonbitlang/core/>) for exact library modules,
+  functions, and signatures.

--- a/skills/moonbit-orientation/references/source-map.md
+++ b/skills/moonbit-orientation/references/source-map.md
@@ -1,0 +1,138 @@
+# Source Map
+
+Use this file as a URL catalog after choosing a lookup path. For step-by-step
+commands, use `lookup-recipes.md`.
+
+## Official documentation
+
+Use official docs for stable language and toolchain concepts:
+
+- Docs home: <https://docs.moonbitlang.com/en/latest/>
+- Tutorials: <https://docs.moonbitlang.com/en/latest/tutorial/index.html>
+- Beginner tour page:
+  <https://docs.moonbitlang.com/en/latest/tutorial/tour.html>
+- Native CLI Quickstart:
+  <https://docs.moonbitlang.com/en/latest/tutorial/cli-quickstart.html>
+- Language docs: syntax, methods, traits, packages, tests, docs, attributes,
+  derive, error handling, FFI, async, benchmarks, verification, and error codes.
+  Start at <https://docs.moonbitlang.com/en/latest/language/index.html>.
+- Toolchain docs: `moon`, packages, workspaces, script mode, coverage, VSCode,
+  `moon ide`, and WebAssembly workflows. Start at
+  <https://docs.moonbitlang.com/en/latest/toolchain/index.html>.
+
+High-use direct links:
+
+- Method and Trait:
+  <https://docs.moonbitlang.com/en/latest/language/methods.html>
+- Regex literals:
+  <https://docs.moonbitlang.com/en/latest/language/fundamentals.html#regex-literal-expression>
+- Regex match expression:
+  <https://docs.moonbitlang.com/en/latest/language/fundamentals.html#regex-match-expression>
+- Error handling:
+  <https://docs.moonbitlang.com/en/latest/language/error-handling.html>
+- Managing Projects with Packages:
+  <https://docs.moonbitlang.com/en/latest/language/packages.html>
+- Writing Tests:
+  <https://docs.moonbitlang.com/en/latest/language/tests.html>
+- FFI: <https://docs.moonbitlang.com/en/latest/language/ffi.html>
+- Async:
+  <https://docs.moonbitlang.com/en/latest/language/async-experimental.html>
+- Verification:
+  <https://docs.moonbitlang.com/en/latest/language/verification.html>
+- `moon` command reference:
+  <https://docs.moonbitlang.com/en/latest/toolchain/moon/commands.html>
+- Module configuration:
+  <https://docs.moonbitlang.com/en/latest/toolchain/moon/module.html>
+- Package configuration:
+  <https://docs.moonbitlang.com/en/latest/toolchain/moon/package.html>
+- Workspace guide:
+  <https://docs.moonbitlang.com/en/latest/toolchain/moon/workspace.html>
+- `moon ide` docs:
+  <https://docs.moonbitlang.com/en/latest/toolchain/moonide/index.html>
+- WebAssembly docs:
+  <https://docs.moonbitlang.com/en/latest/toolchain/wasm/index.html>
+
+## API documentation
+
+Use the current local toolchain before guessing exact standard-library and
+package APIs.
+
+- Prefer `moon ide doc` when a MoonBit project or installed toolchain is
+  available. It queries the compiler/toolchain view of available packages and
+  symbols, so it is usually the best first check for "what API exists here?"
+- Use `moon ide doc ''` to list packages or symbols in context.
+- Use `moon ide doc '@pkg'` to inspect a package, for example `@json` or
+  `@buffer` when available.
+- Use wildcard queries such as `moon ide doc '*parse*'` or
+  `moon ide doc 'String::*rev*'` to discover likely names.
+- Use exact symbol queries such as `moon ide doc '@pkg.Type::member'` when the
+  package and type are known.
+- Use mooncakes.io or package-generated docs when `moon ide doc` is unavailable,
+  when checking packages that are not installed locally, or when the user needs
+  a linkable external reference.
+- Standard library docs: <https://mooncakes.io/docs/moonbitlang/core/>
+- Package registry and package docs: <https://mooncakes.io/>
+- Package management workflow:
+  <https://docs.moonbitlang.com/en/latest/toolchain/moon/package-manage-tour.html>
+- Verify exact module names, function names, signatures, trait methods,
+  constructors, and package-specific behavior.
+- Do not infer exact names from another language's standard library.
+- For ecosystem packages or bindings, package availability may change after the
+  model's training data. Use the registry, package docs, or `moon add` in a
+  real project before saying a package exists or naming an import.
+- If local dependencies are present, inspect dependency declarations and
+  generated interfaces as well.
+
+## Tour
+
+Use the MoonBit Tour (<https://tour.moonbitlang.com/>) for beginner
+explanations and quick interactive examples. It is a good first source for
+learning syntax and core ideas, but not the final source for package-specific
+APIs.
+
+## Examples
+
+Use examples when the user needs runnable structure, not just a definition.
+
+- Check whether the example is a full module, package, single file, or docs
+  snippet.
+- Online examples index:
+  <https://docs.moonbitlang.com/en/latest/example/index.html>.
+- Source examples, when needed:
+  <https://github.com/moonbitlang/moonbit-docs/tree/main/next/sources>.
+- Prefer examples that match the user's target backend and package shape.
+
+## Error-code docs
+
+Use error-code docs for diagnostics with `E####`.
+
+- Error-code index:
+  <https://docs.moonbitlang.com/en/latest/language/error_codes/index.html>.
+- Specific error URL pattern:
+  `https://docs.moonbitlang.com/en/latest/language/error_codes/E####.html`.
+- They are best for explaining the cause and a repair pattern.
+- They may not all have complete paired runnable projects.
+- If examples are missing, rely on the diagnostic, local code, and narrow
+  validation.
+
+## Local project files
+
+Use local files for anything project-specific:
+
+- imports and visibility
+- dependency versions and package names
+- target configuration
+- local style and helper conventions
+- tests and expected outputs
+
+Local truth beats generic guidance when they conflict.
+
+## Installed toolchain truth
+
+Use installed commands for facts that can drift faster than docs:
+
+- `moon ide doc` for currently available APIs and docs.
+- `moon ide peek-def` for definitions.
+- `moon ide find-references` for usages.
+- `moon ide outline` for package or file structure.
+- `moon version` when behavior may differ by toolchain version.

--- a/skills/moonbit-orientation/references/toolchain-map.md
+++ b/skills/moonbit-orientation/references/toolchain-map.md
@@ -1,0 +1,89 @@
+# Toolchain Map
+
+Use local project files as source of truth before changing commands or config.
+
+## Project files
+
+- `moon.mod.json`: module-level metadata and dependencies.
+- `moon.pkg.json`: package-level imports, targets, build settings, and test
+  related settings.
+- Workspace configuration may affect multiple packages or modules. Inspect the
+  repository layout before assuming a single-package project.
+
+## Common `moon` commands
+
+- `moon new <path>`: create a new module.
+- `moon check`: typecheck and validate quickly without building object files.
+- `moon build`: build the current package or module.
+- `moon run <package-or-file>`: run a main package or file.
+- `moon test`: run tests.
+- `moon fmt`: format source; use intentionally scoped formatting in existing
+  projects.
+- `moon doc`: generate documentation.
+- `moon info`: generate public interface files for packages.
+- `moon bench`: run benchmarks.
+- `moon coverage`: coverage utilities.
+- `moon add`, `moon remove`, `moon install`, `moon update`, `moon tree`:
+  dependency and registry workflows.
+- `moon ide doc '<query>'`: discover available packages, symbols, methods, and
+  documentation from the installed toolchain.
+- `moon ide peek-def <symbol>`: find definitions with compiler-aware context.
+- `moon ide find-references <symbol>`: find usages across the project.
+- `moon ide outline <file-or-directory>`: inspect structure before editing.
+
+## API discovery with `moon ide`
+
+Use `moon ide` when the question is "what symbols/packages exist?" or "where is
+this defined?" Text search is still useful, but `moon ide` has compiler context.
+
+- `moon ide doc ''`: list available packages or symbols for the current context.
+- `moon ide doc '@pkg'`: list exported symbols in a package.
+- `moon ide doc 'String'`: inspect a type and its methods.
+- `moon ide doc 'String::*find*'`: wildcard-search methods on a type.
+- `moon ide doc '*parse*'`: wildcard-search symbol names.
+- `moon ide peek-def Type::method`: inspect a definition before changing calls.
+
+If the docs for `moon ide` appear stale, rely on the installed command's output
+and `moon version` for the current environment. The docs entrypoint is
+<https://docs.moonbitlang.com/en/latest/toolchain/moonide/index.html>.
+
+## Targets
+
+- Common stable targets include `wasm`, `wasm-gc`, `js`, `native`, and `all`.
+- `llvm` is nightly-only. Do not recommend it for stable users.
+- `--target all` means `wasm`, `wasm-gc`, `js`, and `native`; it excludes
+  `llvm`.
+- Ask or inspect which target matters before debugging backend behavior.
+- Use `moon check --target all` only when broad target coverage is valuable and
+  the project supports it.
+- For target configuration, use the package configuration docs:
+  <https://docs.moonbitlang.com/en/latest/toolchain/moon/package.html>.
+- If explaining targets to a user, cite the package or module configuration URL
+  above. Do not cite this skill file as the source.
+- Do not invent configuration syntax for combining stable targets with
+  nightly-only `llvm`. State that `llvm` must be handled explicitly on nightly,
+  then point to package/module target configuration docs for exact syntax:
+  <https://docs.moonbitlang.com/en/latest/toolchain/moon/package.html> and
+  <https://docs.moonbitlang.com/en/latest/toolchain/moon/module.html>.
+
+## Tests and docs
+
+- Prefer `moon test` for behavior checks.
+- Prefer `moon check` when only typechecking is needed.
+- Use `moon doc` when documentation generation is the deliverable.
+- Use `moon coverage` when the user's goal is test coverage, not just passing
+  tests.
+
+## Single-file and examples
+
+- `moon check <file>` can be useful for single `.mbt` or `.mbt.md` checks when
+  supported by the toolchain.
+- For examples copied from docs, confirm whether the code is meant to be a
+  standalone project, a package example, or a documentation snippet.
+
+## When not to change tooling
+
+- Do not add dependencies to fix a missing import until the desired package is
+  confirmed.
+- Do not broaden targets to `all` unless cross-target behavior is relevant.
+- Do not run broad formatting across an existing repository unless requested.


### PR DESCRIPTION
## Summary
- add installable `moonbit-orientation` skill under `skills/moonbit-orientation`
- route MoonBit capability, package/API freshness, diagnostics, backend, and toolchain questions to focused references
- keep this PR scoped to the orientation skill only

## Relationship to moonbit-agent-guide
- `moonbit-orientation`: use first for broad MoonBit questions, unknown feature/package/API claims, diagnostics routing, and source-of-truth selection
- `moonbit-agent-guide`: use after the task is concrete project work, for code editing, semantic navigation, tests, formatting, and public API checks

## Validation
- `typos skills/moonbit-orientation`
- `autocorrect skills/moonbit-orientation --lint --no-diff-bg-color`
- `ruby -e 'require "yaml"; YAML.load_file("skills/moonbit-orientation/agents/openai.yaml")'`
