### PR TITLE
feat: add toc.json to tour

### DIFF
--- a/moonbit-tour/README-zh.md
+++ b/moonbit-tour/README-zh.md
@@ -27,13 +27,16 @@ pnpm preview
 
 1. 打开 <http://localhost:8080> 查看 tour 网站。
 
-1. 在章节文件夹下创建一个新的文件夹，遵循命名惯例 `lesson<n>_<lesson-name>` (从 1 开始计数)。
+1. 在章节文件夹下创建一个新的文件夹。现有命名惯例是 `lesson<n>_<lesson-name>`，但教程顺序不再依赖编号。
 
 1. 在创建的文件夹下编写教程内容（`index.md`），并编写教程代码（`index.mbt`）。
 
+1. 将新教程添加到 `tour/toc.json`。`path` 指向教程文件夹，`slug` 控制生成的 URL。调整教程顺序时，只需要移动这个文件里的条目。
+
 ### 添加新的章节
 
-1. 在 `tour` 文件夹下创建一个新的文件夹，遵循命名惯例 `chapter<n>_<chapter-name>`。
+1. 在 `tour` 文件夹下创建一个新的文件夹。现有命名惯例是 `chapter<n>_<chapter-name>`，但章节顺序不再依赖编号。
+1. 将新章节添加到 `tour/toc.json`。`path` 指向章节文件夹，`slug` 控制生成的 URL。
 1. 按照上述步骤添加新的教程。
 
 ## 致谢

--- a/moonbit-tour/README.md
+++ b/moonbit-tour/README.md
@@ -27,13 +27,16 @@ open <http://localhost:3000> to view the tour.
 
 1. open <http://localhost:8080> to view the tour.
 
-1. Create a new folder under the chapter folder following the naming convention `lesson<n>_<lesson-name>` (count start from 1).
+1. Create a new folder under the chapter folder. The existing convention is `lesson<n>_<lesson-name>`, but the lesson order no longer depends on the number.
 
 1. Write the lesson content in `index.md` and lesson code in `index.mbt` under the created folder.
 
+1. Add the lesson to `tour/toc.json`. The `path` points to the lesson folder and the `slug` controls the generated URL. Reorder lessons by moving entries in this file.
+
 ### Add new chapter
 
-1. Create a new folder under `tour` following the naming convention `chapter<n>_<chapter-name>`.
+1. Create a new folder under `tour`. The existing convention is `chapter<n>_<chapter-name>`, but the chapter order no longer depends on the number.
+1. Add the chapter to `tour/toc.json`. The `path` points to the chapter folder and the `slug` controls the generated URL.
 1. Add new lessons following the instruction above.
 
 ## Credit

--- a/moonbit-tour/build/scan-tour.ts
+++ b/moonbit-tour/build/scan-tour.ts
@@ -1,4 +1,3 @@
-import { Dirent } from "fs";
 import fs from "fs/promises";
 import path from "path";
 import * as remark from "./remark";
@@ -12,7 +11,9 @@ export type Chapter = {
 
 type Lesson = {
   chapter: string;
+  chapterSlug: string;
   lesson: string;
+  slug: string;
   title: string;
   index: number;
   total: number;
@@ -26,37 +27,41 @@ type Tour = {
   zh: Chapter[];
 };
 
-async function dirs(path: string, filter?: (d: Dirent) => boolean) {
-  return (await fs.readdir(path, { withFileTypes: true }))
-    .filter((i) => i.isDirectory())
-    .filter(filter ?? (() => true))
-    .sort((a, b) => {
-      const na = +a.name.slice(a.name.search(/\d+/), a.name.search("_"));
-      const nb = +b.name.slice(b.name.search(/\d+/), b.name.search("_"));
-      return na - nb;
-    });
-}
+type TourIndex = {
+  chapters: {
+    path: string;
+    slug: string;
+    lessons: { path: string; slug: string }[];
+  }[];
+};
 
 async function scanTour(): Promise<Tour> {
   async function getChapters(
-    folders: Dirent[],
+    index: TourIndex,
     locale: Locale,
   ): Promise<Chapter[]> {
     const chapters: Chapter[] = [];
-    for (const f of folders) {
-      const chapter = f.name.split("_").slice(1).join(" ");
-      const ds = await dirs(path.join(f.parentPath, f.name));
+    const root = locale === "en" ? "tour" : "tour/zh";
+    for (const chapterEntry of index.chapters) {
+      const chapter = chapterEntry.slug.replaceAll("-", " ");
       const lessons: Lesson[] = await Promise.all(
-        ds.map(async (d, i, arr) => {
-          const lesson = d.name.split("_").slice(1).join(" ");
-          const mdPath = path.join(d.parentPath, d.name, "index.md");
-          const mbtPath = path.join(d.parentPath, d.name, "index.mbt");
+        chapterEntry.lessons.map(async (lessonEntry, i, arr) => {
+          const lesson = lessonEntry.slug.replaceAll("-", " ");
+          const lessonPath = path.join(
+            root,
+            chapterEntry.path,
+            lessonEntry.path,
+          );
+          const mdPath = path.join(lessonPath, "index.md");
+          const mbtPath = path.join(lessonPath, "index.mbt");
           const md = await fs.readFile(mdPath, "utf8");
           const mbt = await fs.readFile(mbtPath, "utf8");
           const title = remark.getFirstH1Title(md) ?? lesson;
           return {
             chapter,
+            chapterSlug: chapterEntry.slug,
             lesson,
+            slug: lessonEntry.slug,
             title,
             index: i,
             total: arr.length,
@@ -66,15 +71,19 @@ async function scanTour(): Promise<Tour> {
           };
         }),
       );
-      chapters.push({ chapter, lessons });
+      chapters.push({
+        chapter,
+        lessons,
+      });
     }
     return chapters;
   }
-  const enChapterFolders = await dirs("tour", (d) => d.name !== "zh");
-  const zhChapterFolders = await dirs("tour/zh");
+  const index = JSON.parse(
+    await fs.readFile("tour/toc.json", "utf8"),
+  ) as TourIndex;
   const [enChapters, zhChapters] = await Promise.all([
-    getChapters(enChapterFolders, "en"),
-    getChapters(zhChapterFolders, "zh"),
+    getChapters(index, "en"),
+    getChapters(index, "zh"),
   ]);
   return {
     en: enChapters,
@@ -84,7 +93,7 @@ async function scanTour(): Promise<Tour> {
 
 function slug(lesson: Lesson): string {
   const prefix = lesson.locale === "zh" ? "zh/" : "";
-  const postfix = `${lesson.chapter.replaceAll(" ", "-")}/${lesson.lesson.replaceAll(" ", "-")}`;
+  const postfix = `${lesson.chapterSlug}/${lesson.slug}`;
   return prefix + postfix;
 }
 

--- a/moonbit-tour/tour/toc.json
+++ b/moonbit-tour/tour/toc.json
@@ -1,0 +1,75 @@
+{
+  "chapters": [
+    {
+      "path": "chapter1_basics",
+      "slug": "basics",
+      "lessons": [
+        { "path": "lesson1_variable", "slug": "variable" },
+        { "path": "lesson2_literal_and_types", "slug": "literal-and-types" },
+        { "path": "lesson3_string", "slug": "string" },
+        { "path": "lesson4_function", "slug": "function" },
+        { "path": "lesson5_block", "slug": "block" },
+        { "path": "lesson6_array", "slug": "array" },
+        { "path": "lesson7_tuple", "slug": "tuple" },
+        { "path": "lesson8_map", "slug": "map" },
+        { "path": "lesson9_if_else", "slug": "if-else" },
+        { "path": "lesson10_loop", "slug": "loop" },
+        { "path": "lesson11_for_in_loop", "slug": "for-in-loop" },
+        { "path": "lesson12_range", "slug": "range" },
+        { "path": "lesson13_exception", "slug": "exception" },
+        { "path": "lesson14_test", "slug": "test" },
+        { "path": "lesson15_module_and_package", "slug": "module-and-package" },
+        { "path": "lesson16_option", "slug": "option" },
+        { "path": "lesson17_result", "slug": "result" }
+      ]
+    },
+    {
+      "path": "chapter2_custom_types",
+      "slug": "custom-types",
+      "lessons": [
+        { "path": "lesson1_struct", "slug": "struct" },
+        { "path": "lesson2_mutable_field", "slug": "mutable-field" },
+        { "path": "lesson3_enum", "slug": "enum" },
+        { "path": "lesson4_tuple_struct", "slug": "tuple-struct" }
+      ]
+    },
+    {
+      "path": "chapter3_pattern_matching",
+      "slug": "pattern-matching",
+      "lessons": [
+        { "path": "lesson1_introduction", "slug": "introduction" },
+        { "path": "lesson2_patterns_in_let", "slug": "patterns-in-let" },
+        { "path": "lesson3_patterns_in_match", "slug": "patterns-in-match" },
+        { "path": "lesson4_constant_pattern", "slug": "constant-pattern" },
+        { "path": "lesson5_tuple_pattern", "slug": "tuple-pattern" },
+        { "path": "lesson6_alias_pattern", "slug": "alias-pattern" },
+        { "path": "lesson7_array_pattern", "slug": "array-pattern" },
+        { "path": "lesson8_or_pattern", "slug": "or-pattern" },
+        { "path": "lesson9_range_pattern", "slug": "range-pattern" },
+        { "path": "lesson10_guard_condition", "slug": "guard-condition" },
+        { "path": "lesson11_map_pattern", "slug": "map-pattern" }
+      ]
+    },
+    {
+      "path": "chapter4_more_data_types",
+      "slug": "more-data-types",
+      "lessons": [
+        { "path": "lesson1_immutable_list", "slug": "immutable-list" },
+        { "path": "lesson2_immutable_set", "slug": "immutable-set" },
+        { "path": "lesson3_immutable_map", "slug": "immutable-map" }
+      ]
+    },
+    {
+      "path": "chapter5_methods_generics_and_traits",
+      "slug": "methods-generics-and-traits",
+      "lessons": [
+        { "path": "lesson1_methods", "slug": "methods" },
+        { "path": "lesson2_local_methods", "slug": "local-methods" },
+        { "path": "lesson3_generic_function", "slug": "generic-function" },
+        { "path": "lesson4_generic_type", "slug": "generic-type" },
+        { "path": "lesson5_trait_and_impl", "slug": "trait-and-impl" },
+        { "path": "lesson6_trait_bound", "slug": "trait-bound" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION

  Switch the MoonBit tour ordering from directory-number scanning to an explicit `tour/toc.json`.

  This makes it easier to insert lessons or adjust chapter/lesson order without renaming folders. The existing lesson
  content layout is preserved, while `toc.json` now controls the generated order and URL slugs.

  Also updates the tour README files to document the new workflow for adding chapters and lessons.