### PR TITLE
[codex] Add extenum documentation

### DIFF
--- a/next/language/fundamentals.md
+++ b/next/language/fundamentals.md
@@ -1437,6 +1437,57 @@ It is also possible to define mutable fields for constructor. This is especially
 :end-before: end enum 12
 ```
 
+#### Extensible enum
+
+An `extenum` defines an open enum type. Unlike a regular `enum`, an
+`extenum` can receive more constructors later, including from another package.
+This is useful when a package wants to define the shared event, message, or
+extension-point type, while other packages contribute their own cases.
+
+```{literalinclude} /sources/language/src/extenum/base/top.mbt
+:language: moonbit
+:start-after: start extenum declare
+:end-before: end extenum declare
+```
+
+Use `extenum Type += { ... }` to add constructors to an extensible enum in the
+same package:
+
+```{literalinclude} /sources/language/src/extenum/base/top.mbt
+:language: moonbit
+:start-after: start extenum local extension
+:end-before: end extenum local extension
+```
+
+To extend an extensible enum from another package, qualify the target type with
+the package that defines the type:
+
+```{literalinclude} /sources/language/src/extenum/plugin/top.mbt
+:language: moonbit
+:start-after: start extenum foreign extension
+:end-before: end extenum foreign extension
+```
+
+Extensible enum constructors are qualified by the package that defines the
+constructor. For constructors from the current package, use the constructor name
+directly when the expected type is known. For constructors from another
+package, use `@pkg.Constructor` in expressions and patterns.
+
+When a package imports both the base package and an extension package, values
+from both packages have the same extensible enum type:
+
+```{literalinclude} /sources/language/src/extenum/app/top.mbt
+:language: moonbit
+:start-after: start extenum interaction
+:end-before: end extenum interaction
+```
+
+Pattern matching must include a wildcard branch, because more constructors
+can be added outside the current declaration.
+
+Only `extenum` declarations can be extended. Regular `enum` declarations are
+closed.
+
 ### Tuple Struct
 
 MoonBit supports a special kind of struct called tuple struct:

--- a/next/language/introduction.md
+++ b/next/language/introduction.md
@@ -86,11 +86,12 @@ The following are the keywords and should not be used:
 ```json
 [
   "as", "else", "extern", "fn", "fnalias", "if", "let", "const", "match", "using",
-  "mut", "type", "typealias", "struct", "enum", "trait", "traitalias", "derive",
-  "declare", "while", "break", "continue", "import", "return", "throw", "raise",
-  "try", "catch", "pub", "priv", "readonly", "true", "false", "_", "test", "loop",
-  "for", "in", "impl", "with", "guard", "async", "is", "suberror", "and", "letrec",
-  "enumview", "noraise", "defer",
+  "mut", "type", "typealias", "struct", "enum", "extenum", "trait",
+  "traitalias", "derive", "while", "break", "continue", "import", "return",
+  "throw", "raise", "try", "catch", "pub", "priv", "proof_assert", "proof_let",
+  "readonly", "true", "false", "_", "test", "loop", "for", "in", "impl", "with",
+  "guard", "async", "is", "suberror", "and", "letrec", "enumview", "noraise",
+  "defer", "lexmatch", "where", "declare", "nobreak",
 ]
 ```
 
@@ -101,14 +102,14 @@ They might be turned into keywords in the future.
 
 ```json
 [
-  "module", "move", "ref", "static", "super", "unsafe", "use", "where", "await",
+  "module", "move", "ref", "static", "super", "unsafe", "use", "await",
   "dyn", "abstract", "do", "final", "macro", "override", "typeof", "virtual", "yield",
   "local", "method", "alias", "assert", "package", "recur", "using", "enumview",
   "isnot", "define", "downcast", "inherit", "member", "namespace", "static", "upcast",
   "use", "void", "lazy", "include", "mixin", "protected", "sealed", "constructor",
   "atomic", "volatile", "anyframe", "anytype", "asm", "await", "comptime", "errdefer",
   "export", "opaque", "orelse", "resume", "threadlocal", "unreachable", "dynclass",
-  "dynobj", "dynrec", "var", "finally", "noasync",
+  "dynobj", "dynrec", "var", "finally", "noasync", "assume",
 ]
 ```
 

--- a/next/sources/language/src/extenum/app/moon.pkg.json
+++ b/next/sources/language/src/extenum/app/moon.pkg.json
@@ -1,0 +1,14 @@
+{
+  "import": [
+    {
+      "path": "moonbit-community/language/extenum/base",
+      "alias": "base"
+    },
+    {
+      "path": "moonbit-community/language/extenum/plugin",
+      "alias": "plugin"
+    },
+    "moonbitlang/core/test"
+  ],
+  "warn-list": "-unused_value"
+}

--- a/next/sources/language/src/extenum/app/top.mbt
+++ b/next/sources/language/src/extenum/app/top.mbt
@@ -1,0 +1,25 @@
+// start extenum interaction
+pub fn describe(event : @base.LogEvent[String]) -> String {
+  match event {
+    @base.Info(message) => "info: \{message}"
+    @base.Warning(message) => "warning: \{message}"
+    @base.Critical(code, message) => "critical \{code}: \{message}"
+    @plugin.Debug(message) => "debug: \{message}"
+    _ => "unknown"
+  }
+}
+
+pub fn debug_event(message : String) -> @base.LogEvent[String] {
+  @plugin.Debug(message)
+}
+// end extenum interaction
+
+test "extenum interaction" {
+  inspect(describe(@base.Info("started")), content="info: started")
+  inspect(describe(@base.Warning("retrying")), content="warning: retrying")
+  inspect(
+    describe(@base.Critical("E_CONN", "database unavailable")),
+    content="critical E_CONN: database unavailable",
+  )
+  inspect(describe(debug_event("verbose trace")), content="debug: verbose trace")
+}

--- a/next/sources/language/src/extenum/base/moon.pkg.json
+++ b/next/sources/language/src/extenum/base/moon.pkg.json
@@ -1,0 +1,3 @@
+{
+  "warn-list": "-unused_value-unused_constructor"
+}

--- a/next/sources/language/src/extenum/base/top.mbt
+++ b/next/sources/language/src/extenum/base/top.mbt
@@ -1,0 +1,12 @@
+// start extenum declare
+pub(all) extenum LogEvent[T] {
+  Info(T)
+}
+// end extenum declare
+
+// start extenum local extension
+pub(all) extenum LogEvent[T] += {
+  Warning(T)
+  Critical(T, T)
+}
+// end extenum local extension

--- a/next/sources/language/src/extenum/plugin/moon.pkg.json
+++ b/next/sources/language/src/extenum/plugin/moon.pkg.json
@@ -1,0 +1,9 @@
+{
+  "import": [
+    {
+      "path": "moonbit-community/language/extenum/base",
+      "alias": "base"
+    }
+  ],
+  "warn-list": "-unused_constructor"
+}

--- a/next/sources/language/src/extenum/plugin/top.mbt
+++ b/next/sources/language/src/extenum/plugin/top.mbt
@@ -1,0 +1,5 @@
+// start extenum foreign extension
+pub(all) extenum @base.LogEvent[T] += {
+  Debug(T)
+}
+// end extenum foreign extension


### PR DESCRIPTION
## Summary

- Document `extenum` in the language fundamentals enum section.
- Add source-backed `literalinclude` examples for extensible enum declarations, same-package extensions, foreign package extensions, and cross-package construction/matching.
- Sync the keyword and reserved keyword lists with the compiler keyword table.

## Why

The `next` documentation covered regular `enum` declarations but did not describe extensible enums. The keyword list was also missing newer compiler keywords and still listed `where` as reserved even though it is now a keyword.

## Validation

- Stable MoonBit: `moon check src/extenum/base src/extenum/plugin src/extenum/app --target all --deny-warn`
- Stable MoonBit: `moon test src/extenum/base src/extenum/plugin src/extenum/app --target all --deny-warn`
- `just docs-html` passes with existing unrelated warnings about missing download summaries and `pilot/index.md` not being in a toctree.
