### PR TITLE
[codex] Document mbtx command scripts

### DIFF
--- a/.github/workflows/next-check.yml
+++ b/.github/workflows/next-check.yml
@@ -43,3 +43,7 @@ jobs:
       - name: Workspace command transcript
         shell: bash
         run: scrut test --shell bash next/sources/workspace/workspace.cram
+
+      - name: Script mode command transcript
+        shell: bash
+        run: scrut test --shell bash next/sources/script-mode/script-mode.cram

--- a/next/locales/ja/LC_MESSAGES/toolchain/moon/script-mode.po
+++ b/next/locales/ja/LC_MESSAGES/toolchain/moon/script-mode.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MoonBit \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-11 16:40+0800\n"
+"POT-Creation-Date: 2026-05-09 12:05+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ja\n"
@@ -130,10 +130,20 @@ msgid "$ cat script.mbtx | moon run -\n"
 msgstr "$ cat script.mbtx | moon run -\n"
 
 #: ../../toolchain/moon/script-mode.md:60
+msgid "For short scripts, pass the `.mbtx` source directly with `-c`:"
+msgstr "短いスクリプトでは、`-c` で `.mbtx` ソースを直接渡せます："
+
+#: ../../toolchain/moon/script-mode.md:62
+msgid ""
+"$ moon run -c \"<script>\"\n"
+"$ moon run -c 'fn main { println(\"hello\") }'\n"
+msgstr ""
+
+#: ../../toolchain/moon/script-mode.md:67
 msgid "You can also use a heredoc, a feature provided by the shell:"
 msgstr "シェルが提供する機能である heredoc も使えます："
 
-#: ../../toolchain/moon/script-mode.md:62
+#: ../../toolchain/moon/script-mode.md:69
 msgid ""
 "$ moon run - <<EOF\n"
 "fn main {\n"

--- a/next/locales/zh_CN/LC_MESSAGES/toolchain/moon/script-mode.po
+++ b/next/locales/zh_CN/LC_MESSAGES/toolchain/moon/script-mode.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MoonBit \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-11 16:40+0800\n"
+"POT-Creation-Date: 2026-05-09 12:05+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: zh_CN\n"
@@ -123,10 +123,20 @@ msgid "$ cat script.mbtx | moon run -\n"
 msgstr "$ cat script.mbtx | moon run -\n"
 
 #: ../../toolchain/moon/script-mode.md:60
+msgid "For short scripts, pass the `.mbtx` source directly with `-c`:"
+msgstr "对于简短脚本，可以使用 `-c` 直接传入 `.mbtx` 源码："
+
+#: ../../toolchain/moon/script-mode.md:62
+msgid ""
+"$ moon run -c \"<script>\"\n"
+"$ moon run -c 'fn main { println(\"hello\") }'\n"
+msgstr ""
+
+#: ../../toolchain/moon/script-mode.md:67
 msgid "You can also use a heredoc, a feature provided by the shell:"
 msgstr "你也可以使用 heredoc（由 shell 提供的一项功能）："
 
-#: ../../toolchain/moon/script-mode.md:62
+#: ../../toolchain/moon/script-mode.md:69
 msgid ""
 "$ moon run - <<EOF\n"
 "fn main {\n"

--- a/next/sources/script-mode/script-mode.cram
+++ b/next/sources/script-mode/script-mode.cram
@@ -1,0 +1,3 @@
+Script mode command transcript
+  $ moon run -c 'fn main { println("hello") }'
+  hello

--- a/next/toolchain/moon/script-mode.md
+++ b/next/toolchain/moon/script-mode.md
@@ -57,6 +57,13 @@ Moon supports running a `.mbtx` script from stdin:
 $ cat script.mbtx | moon run -
 ```
 
+For short scripts, pass the `.mbtx` source directly with `-c`:
+
+```
+$ moon run -c "<script>"
+$ moon run -c 'fn main { println("hello") }'
+```
+
 You can also use a heredoc, a feature provided by the shell:
 
 ```

--- a/scripts/check-document.py
+++ b/scripts/check-document.py
@@ -11,8 +11,9 @@ def main():
         if not dir_path.is_dir() or dir_path.name.startswith('.') or dir_path.name == "target":
             continue
 
-        # Skip error codes; they should be handled with another script
-        if dir_path.name == "error_codes":
+        # Skip error codes; they should be handled with another script.
+        # Script mode has command transcripts checked by scrut.
+        if dir_path.name in {"error_codes", "script-mode"}:
             continue
 
         # These examples require the native backend.


### PR DESCRIPTION
## Summary

- Document `moon run -c "<script>"` for short `.mbtx` scripts.
- Add Chinese and Japanese translations for the new script-mode text.
- Add a `scrut` transcript for `moon run -c` and run it in the docs example workflow.
- Skip the transcript-only `next/sources/script-mode` directory in the MoonBit example checker.

## Validation

- `scrut test --shell bash next/sources/script-mode/script-mode.cram`
- `just docs-html-zh` passed with existing warnings.
- `just docs-html-ja` passed with existing warnings.
- `git diff --check`

## Notes

`just check-docs` still fails on existing unrelated MoonBit example drift in `async`, `cli-quickstart`, `diff`, `fullstack-one-project`, `language`, and `verification`; the new `script-mode` directory is skipped as intended and covered by `scrut`.