### PR TITLE
[codex] Check error-code examples in CI

### DIFF
--- a/.github/workflows/next-check.yml
+++ b/.github/workflows/next-check.yml
@@ -34,6 +34,10 @@ jobs:
         run: |
           python scripts/check-document.py
 
+      - name: check error-code examples
+        run: |
+          python next/check_error_docs.py all
+
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 


### PR DESCRIPTION
## Summary
- add `python next/check_error_docs.py all` to the next docs example CI workflow
- keep the CI check in non-strict mode so existing monitored examples are validated without blocking on historical coverage gaps

## Validation
- python3 next/check_error_docs.py all
- git diff --check