### PR TITLE
docs: fix Japanese typo in fundamentals

### DIFF
--- a/next/locales/ja/LC_MESSAGES/language/fundamentals.po
+++ b/next/locales/ja/LC_MESSAGES/language/fundamentals.po
@@ -5588,7 +5588,7 @@ msgid ""
 " for consecutive operations without the need to modify the return type of"
 " the methods."
 msgstr ""
-"`builder` を何度も টাইピングしないようにするため、そのメソッドはしばしば `self` 自身を返すように設計され、`.` "
+"`builder` を何度もタイピングしないようにするため、そのメソッドはしばしば `self` 自身を返すように設計され、`.` "
 "演算子で操作を連結できます。immutable な操作と mutable な操作を区別するために、MoonBit では `Unit` "
 "を返すすべてのメソッドに対して、戻り値型を変更せずに連続した操作を行うためにカスケード演算子を使えます。"
 


### PR DESCRIPTION
This PR fixes an unintended Bengali-script word in the Japanese translation.

I only changed `টাইピング` to `タイピング`.