### PR TITLE
docs: fix warning error examples

### DIFF
--- a/next/language/error_codes/E4096.md
+++ b/next/language/error_codes/E4096.md
@@ -9,7 +9,7 @@ Only `String` supports string interpolation.
 ```
 
 ## Suggestion
-To dynamically create a `Bytes`, use `@buffer.T` instead:
+To dynamically create a `Bytes`, use `Buffer` with explicit UTF-8 writes:
 
 ```{literalinclude} /sources/error_codes/4096_fixed/top.mbt
 :language: moonbit

--- a/next/sources/error_codes/0071_error/top.mbt
+++ b/next/sources/error_codes/0071_error/top.mbt
@@ -1,6 +1,6 @@
 ///|
 fn make_buffer() -> @buffer.Buffer {
-  @buffer.new()
+  Buffer()
 }
 
 ///|

--- a/next/sources/error_codes/0071_fixed/top.mbt
+++ b/next/sources/error_codes/0071_fixed/top.mbt
@@ -1,6 +1,6 @@
 ///|
 fn make_buffer() -> @buffer.Buffer {
-  @buffer.new()
+  Buffer()
 }
 
 ///|

--- a/next/sources/error_codes/4004_error/top.mbt
+++ b/next/sources/error_codes/4004_error/top.mbt
@@ -1,3 +1,3 @@
 trait Stringer {
-  stringify[T : Show](Self, T) -> String
+  fn[T : Show] stringify(Self, T) -> String
 }

--- a/next/sources/error_codes/4096_fixed/top.mbt
+++ b/next/sources/error_codes/4096_fixed/top.mbt
@@ -1,11 +1,11 @@
 ///|
 test {
   let x : Int = 42
-  let buf = @buffer.new()
+  let buf = Buffer()
   let bytes : Bytes = buf
-    ..write_string("(")
-    ..write_object(x)
-    ..write_string(")")
+    ..write_string_utf8("(")
+    ..write_utf8(x)
+    ..write_string_utf8(")")
     .to_bytes()
   ignore(bytes)
 }


### PR DESCRIPTION
## Summary

- Update the E0071 buffer examples to avoid unrelated deprecation warnings.
- Update the E4004 repro to the current polymorphic function syntax so it emits E4004.
- Update the E4096 fixed example and suggestion text to use explicit UTF-8 buffer writes.

## Stack

This PR is based on #1247 because the current stable toolchain also requires its broader document-example updates for CI to pass.

## Root Cause

The examples had drifted from the stable compiler behavior: deprecated buffer APIs produced extra warnings, and the old generic method syntax no longer reached the documented E4004 diagnostic.

## Validation

- `just check-error 0071`
- `just check-error 4004`
- `just check-error 4096`
- `python3 scripts/check-document.py`