### PR TITLE
[codex] docs: add lexmatch warning docs

### DIFF
--- a/language/error_codes/E0076.md
+++ b/language/error_codes/E0076.md
@@ -1,0 +1,14 @@
+# E0076
+
+Warning name: `lexmatch_first_match`
+
+Using `lexmatch` with first-match semantics.
+
+`lexmatch` and `lexmatch?` are deprecated. First-match `lexmatch` searches with
+the legacy regex syntax. For new code, prefer regex match expressions with `=~`
+when first-match or search behavior is enough.
+
+## Suggestion
+
+Rewrite first-match `lexmatch` checks as regex match expressions unless you are
+maintaining existing legacy code.

--- a/language/error_codes/E0077.md
+++ b/language/error_codes/E0077.md
@@ -1,0 +1,15 @@
+# E0077
+
+Warning name: `lexmatch_longest_match`
+
+Using `lexmatch` with longest-match semantics.
+
+`lexmatch ... with longest` is the legacy lexer-style matching mode. It remains
+available for code that needs longest-match selection among alternatives. When
+that behavior is not required, prefer regex match expressions with `=~` in new
+code.
+
+## Suggestion
+
+Keep `lexmatch ... with longest` only when longest-match behavior is required.
+Otherwise, rewrite the match with regex match expressions.

--- a/language/error_codes/index.md
+++ b/language/error_codes/index.md
@@ -82,6 +82,8 @@ This page lists all error codes produced by the MoonBit compiler.
 * [E0073](E0073.md)
 * [E0074](E0074.md)
 * [E0075](E0075.md)
+* [E0076](E0076.md)
+* [E0077](E0077.md)
 * [E1000](E1000.md)
 * [E1001](E1001.md)
 * [E3001](E3001.md)


### PR DESCRIPTION
## Summary

- Add internal error-code pages for `E0076` and `E0077`.
- Add the new warning docs to the error-code index.

## Context

The current nightly compiler reports two new `lexmatch` warnings in `moonc check -warn-help`. Moon's integrated diagnostic docs need matching entries so `moon explain --diagnostic` can resolve the new warning IDs.

## Validation

Validated through the Moon repo tests that consume this docs submodule update:

- `cargo test -p moon cli::explain -- --nocapture`
- `cargo test -p moon test_moon_explain -- --nocapture`