### PR TITLE
[codex] add lexmatch warning docs

### DIFF
--- a/next/language/error_codes/E0076.md
+++ b/next/language/error_codes/E0076.md
@@ -1,0 +1,25 @@
+# E0076
+
+Warning name: `lexmatch_first_match`
+
+Using `lexmatch` with first-match semantics is deprecated.
+
+This warning is emitted for `lexmatch` expressions that use the default
+first-match strategy, including `lexmatch ... with first`. Prefer regex match
+expressions for ordinary regex checks in new code.
+
+## Erroneous example
+
+```{literalinclude} /sources/error_codes/0076_error/top.mbt
+:language: moonbit
+```
+
+## Suggestion
+
+Rewrite first-match `lexmatch` code with a regex match expression when possible.
+If you specifically need lexer-style longest-match behavior, make that explicit
+with `lexmatch ... with longest`.
+
+```{literalinclude} /sources/error_codes/0076_fixed/top.mbt
+:language: moonbit
+```

--- a/next/language/error_codes/E0077.md
+++ b/next/language/error_codes/E0077.md
@@ -1,0 +1,28 @@
+# E0077
+
+Warning name: `lexmatch_longest_match`
+
+Using `lexmatch` with longest-match semantics.
+
+This warning is disabled by default. It can be enabled to audit remaining
+`lexmatch ... with longest` usages. Regex match expressions do not provide
+longest-match semantics, so code that relies on lexer-style longest matching
+may need to keep `lexmatch ... with longest`.
+
+## Erroneous example
+
+```{literalinclude} /sources/error_codes/0077_error/top.mbt
+:language: moonbit
+```
+
+## Suggestion
+
+If longest-match behavior is not required, rewrite the code without `lexmatch`.
+For example, use a regex match expression for a full-string regex check.
+
+If longest-match behavior is required, keep `lexmatch ... with longest` and
+leave this audit warning disabled or suppress it locally.
+
+```{literalinclude} /sources/error_codes/0077_fixed/top.mbt
+:language: moonbit
+```

--- a/next/locales/zh_CN/LC_MESSAGES/language/error_codes/E0076.po
+++ b/next/locales/zh_CN/LC_MESSAGES/language/error_codes/E0076.po
@@ -1,0 +1,92 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026, International Digital Economy Academy
+# This file is distributed under the same license as the MoonBit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MoonBit \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-01 14:14+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../language/error_codes/E0076.md:1
+msgid "E0076"
+msgstr ""
+
+#: ../../language/error_codes/E0076.md:3
+msgid "Warning name: `lexmatch_first_match`"
+msgstr ""
+
+#: ../../language/error_codes/E0076.md:5
+msgid "Using `lexmatch` with first-match semantics is deprecated."
+msgstr "使用 first-match 语义的 `lexmatch` 已弃用。"
+
+#: ../../language/error_codes/E0076.md:7
+msgid ""
+"This warning is emitted for `lexmatch` expressions that use the default "
+"first-match strategy, including `lexmatch ... with first`. Prefer regex "
+"match expressions for ordinary regex checks in new code."
+msgstr ""
+"当 `lexmatch` 表达式使用默认的 first-match 策略时会触发此警告，"
+"包括 `lexmatch ... with first`。在新代码中，普通正则检查应优先使用"
+"正则匹配表达式。"
+
+#: ../../language/error_codes/E0076.md:11
+msgid "Erroneous example"
+msgstr "错误示例"
+
+#: ../../language/error_codes/E0076.md:13
+msgid ""
+"///|\n"
+"fn classify(input : String) -> String {\n"
+"  lexmatch input {\n"
+"    \"if\" => \"keyword\"\n"
+"    _ => \"other\"\n"
+"  }\n"
+"}\n"
+"\n"
+"///|\n"
+"test {\n"
+"  ignore(classify)\n"
+"}\n"
+msgstr ""
+
+#: ../../language/error_codes/E0076.md:17
+msgid "Suggestion"
+msgstr "建议"
+
+#: ../../language/error_codes/E0076.md:19
+msgid ""
+"Rewrite first-match `lexmatch` code with a regex match expression when "
+"possible. If you specifically need lexer-style longest-match behavior, "
+"make that explicit with `lexmatch ... with longest`."
+msgstr ""
+"尽可能将 first-match `lexmatch` 代码改写为正则匹配表达式。"
+"如果确实需要词法分析器风格的 longest-match 行为，"
+"请使用 `lexmatch ... with longest` 显式写出。"
+
+#: ../../language/error_codes/E0076.md:23
+msgid ""
+"///|\n"
+"fn classify(input : String) -> String {\n"
+"  if input =~ re\"^if$\" {\n"
+"    \"keyword\"\n"
+"  } else {\n"
+"    \"other\"\n"
+"  }\n"
+"}\n"
+"\n"
+"///|\n"
+"test {\n"
+"  ignore(classify)\n"
+"}\n"
+msgstr ""

--- a/next/locales/zh_CN/LC_MESSAGES/language/error_codes/E0077.po
+++ b/next/locales/zh_CN/LC_MESSAGES/language/error_codes/E0077.po
@@ -1,0 +1,97 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026, International Digital Economy Academy
+# This file is distributed under the same license as the MoonBit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MoonBit \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-01 14:14+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../language/error_codes/E0077.md:1
+msgid "E0077"
+msgstr ""
+
+#: ../../language/error_codes/E0077.md:3
+msgid "Warning name: `lexmatch_longest_match`"
+msgstr ""
+
+#: ../../language/error_codes/E0077.md:5
+msgid "Using `lexmatch` with longest-match semantics."
+msgstr "使用 longest-match 语义的 `lexmatch`。"
+
+#: ../../language/error_codes/E0077.md:7
+msgid ""
+"This warning is disabled by default. It can be enabled to audit remaining"
+" `lexmatch ... with longest` usages. Regex match expressions do not "
+"provide longest-match semantics, so code that relies on lexer-style "
+"longest matching may need to keep `lexmatch ... with longest`."
+msgstr ""
+"此警告默认关闭。可以启用它来审查剩余的 "
+"`lexmatch ... with longest` 用法。正则匹配表达式不提供 longest-match "
+"语义，因此依赖词法分析器风格最长匹配的代码可能需要保留 "
+"`lexmatch ... with longest`。"
+
+#: ../../language/error_codes/E0077.md:12
+msgid "Erroneous example"
+msgstr "错误示例"
+
+#: ../../language/error_codes/E0077.md:14
+msgid ""
+"///|\n"
+"fn is_keyword(input : String) -> Bool {\n"
+"  lexmatch input with longest {\n"
+"    \"if\" => true\n"
+"    _ => false\n"
+"  }\n"
+"}\n"
+"\n"
+"///|\n"
+"test {\n"
+"  ignore(is_keyword)\n"
+"}\n"
+msgstr ""
+
+#: ../../language/error_codes/E0077.md:18
+msgid "Suggestion"
+msgstr "建议"
+
+#: ../../language/error_codes/E0077.md:20
+msgid ""
+"If longest-match behavior is not required, rewrite the code without "
+"`lexmatch`. For example, use a regex match expression for a full-string "
+"regex check."
+msgstr ""
+"如果不需要 longest-match 行为，请改写代码以避免使用 `lexmatch`。"
+"例如，对于全字符串正则检查，可以使用正则匹配表达式。"
+
+#: ../../language/error_codes/E0077.md:23
+msgid ""
+"If longest-match behavior is required, keep `lexmatch ... with longest` "
+"and leave this audit warning disabled or suppress it locally."
+msgstr ""
+"如果需要 longest-match 行为，请保留 `lexmatch ... with longest`，"
+"并让这个审查用警告保持关闭，或在局部抑制它。"
+
+#: ../../language/error_codes/E0077.md:26
+msgid ""
+"///|\n"
+"fn is_keyword(input : String) -> Bool {\n"
+"  input =~ re\"^if$\"\n"
+"}\n"
+"\n"
+"///|\n"
+"test {\n"
+"  ignore(is_keyword)\n"
+"}\n"
+msgstr ""

--- a/next/sources/error_codes/0076_error/moon.mod.json
+++ b/next/sources/error_codes/0076_error/moon.mod.json
@@ -1,0 +1,1 @@
+{"name": "moonbit-community/E0076-error"}

--- a/next/sources/error_codes/0076_error/moon.pkg
+++ b/next/sources/error_codes/0076_error/moon.pkg
@@ -1,0 +1,1 @@
+warnings = "-unused_value"

--- a/next/sources/error_codes/0076_error/top.mbt
+++ b/next/sources/error_codes/0076_error/top.mbt
@@ -1,0 +1,12 @@
+///|
+fn classify(input : String) -> String {
+  lexmatch input {
+    "if" => "keyword"
+    _ => "other"
+  }
+}
+
+///|
+test {
+  ignore(classify)
+}

--- a/next/sources/error_codes/0076_fixed/moon.mod.json
+++ b/next/sources/error_codes/0076_fixed/moon.mod.json
@@ -1,0 +1,1 @@
+{"name": "moonbit-community/E0076-fixed"}

--- a/next/sources/error_codes/0076_fixed/moon.pkg
+++ b/next/sources/error_codes/0076_fixed/moon.pkg
@@ -1,0 +1,1 @@
+warnings = "-unused_value"

--- a/next/sources/error_codes/0076_fixed/top.mbt
+++ b/next/sources/error_codes/0076_fixed/top.mbt
@@ -1,0 +1,13 @@
+///|
+fn classify(input : String) -> String {
+  if input =~ re"^if$" {
+    "keyword"
+  } else {
+    "other"
+  }
+}
+
+///|
+test {
+  ignore(classify)
+}

--- a/next/sources/error_codes/0077_error/moon.mod.json
+++ b/next/sources/error_codes/0077_error/moon.mod.json
@@ -1,0 +1,1 @@
+{"name": "moonbit-community/E0077-error"}

--- a/next/sources/error_codes/0077_error/moon.pkg
+++ b/next/sources/error_codes/0077_error/moon.pkg
@@ -1,0 +1,1 @@
+warnings = "-unused_value+lexmatch_longest_match"

--- a/next/sources/error_codes/0077_error/top.mbt
+++ b/next/sources/error_codes/0077_error/top.mbt
@@ -1,0 +1,12 @@
+///|
+fn is_keyword(input : String) -> Bool {
+  lexmatch input with longest {
+    "if" => true
+    _ => false
+  }
+}
+
+///|
+test {
+  ignore(is_keyword)
+}

--- a/next/sources/error_codes/0077_fixed/moon.mod.json
+++ b/next/sources/error_codes/0077_fixed/moon.mod.json
@@ -1,0 +1,1 @@
+{"name": "moonbit-community/E0077-fixed"}

--- a/next/sources/error_codes/0077_fixed/moon.pkg
+++ b/next/sources/error_codes/0077_fixed/moon.pkg
@@ -1,0 +1,1 @@
+warnings = "-unused_value"

--- a/next/sources/error_codes/0077_fixed/top.mbt
+++ b/next/sources/error_codes/0077_fixed/top.mbt
@@ -1,0 +1,9 @@
+///|
+fn is_keyword(input : String) -> Bool {
+  input =~ re"^if$"
+}
+
+///|
+test {
+  ignore(is_keyword)
+}


### PR DESCRIPTION
## Summary

- Add `E0076` and `E0077` documentation for the dedicated `lexmatch` warning codes.
- Add paired error/fixed example projects for both warning codes.
- Add Chinese translations for the new warning documentation.

## Validation

- Targeted compiler checks for `0076_error`, `0076_fixed`, `0077_error`, and `0077_fixed`
- `just docs-html`
- `just docs-html-zh`
