### PR TITLE
fix(ci): generate markdown downloads for zh release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,9 @@ jobs:
       - name: install
         run: pip install -r requirements.txt
       - name: build
-        run: LANGUAGE="zh_CN" make html
+        run: |
+          LANGUAGE="zh_CN" python3 llm.py
+          LANGUAGE="zh_CN" make html
       - uses: aliyun/setup-aliyun-cli-action@v1
       - name: upload
         run: |


### PR DESCRIPTION
## Why
The Chinese OSS release build runs the Sphinx HTML build directly, so the section Markdown summary files are absent when Sphinx resolves the download links. That makes entries such as the tutorial Markdown download render as non-clickable text on docs.moonbitlang.cn.

## What
Run llm.py with LANGUAGE=zh_CN before the Chinese HTML build so the download summaries exist before Sphinx resolves path:/download/... links.

## Correctness
This matches the existing Read the Docs and linkcheck build ordering while preserving Chinese output for the generated summaries. The change is limited to the zh release workflow; source docs and translation catalogs are unchanged.