### PR TITLE
Add error docs for 4120, 4198, 4201, and 4211

### DIFF
--- a/next/language/error_codes/E4120.md
+++ b/next/language/error_codes/E4120.md
@@ -1,0 +1,18 @@
+# E4120
+
+Compiler diagnostic name: `unhandled_error`.
+
+An infix operator application may raise an error, but the error is not handled.
+
+Most error-producing function calls are checked directly at the call site. This
+diagnostic is used for operator applications after the operator has been
+resolved to a function whose effect may raise. The operation must either handle
+the error locally or appear in a context that can propagate it.
+
+This diagnostic is currently tied to an operator-resolution path and is not
+monitored by a source-level error-code example.
+
+## Suggestion
+
+Handle the error with `try`/`catch`, or use the operator only inside a function
+whose signature permits the raised error.

--- a/next/language/error_codes/E4198.md
+++ b/next/language/error_codes/E4198.md
@@ -1,0 +1,20 @@
+# E4198
+
+Compiler diagnostic name: `struct_constr_not_implemented`.
+
+A struct declares a constructor, but the matching constructor implementation is
+missing or is not a regular implementation of that constructor.
+
+Struct constructor declarations and implementations must agree on the same
+constructor function. An alias or trait implementation is not enough to satisfy
+the declaration.
+
+This diagnostic is produced by the struct-constructor consistency checker. The
+legacy declaration form that reaches this checker is currently rejected earlier
+by the parser/deprecation diagnostics, so this page is not monitored by a
+source-level error-code example.
+
+## Suggestion
+
+Define the constructor as the regular struct constructor function, and make its
+parameter list and return type match the declaration.

--- a/next/language/error_codes/E4201.md
+++ b/next/language/error_codes/E4201.md
@@ -1,0 +1,20 @@
+# E4201
+
+Compiler diagnostic name: `struct_constr_inconsistent_impl`.
+
+A struct constructor implementation has an inconsistent type compared with the
+constructor declaration on the struct.
+
+The constructor's parameter arity, type parameters, effects, and return type
+must match the declaration. In particular, a constructor for `struct T` must
+construct `T` with the declared signature.
+
+This diagnostic is produced by the struct-constructor consistency checker. The
+legacy declaration form that reaches this checker is currently rejected earlier
+by the parser/deprecation diagnostics, so this page is not monitored by a
+source-level error-code example.
+
+## Suggestion
+
+Update either the constructor declaration or the implementation so both sides
+describe the same function type.

--- a/next/language/error_codes/E4211.md
+++ b/next/language/error_codes/E4211.md
@@ -1,0 +1,27 @@
+# E4211
+
+Compiler diagnostic name: `control_in_list_comprehension`.
+
+`return`, `break`, `continue`, and error-producing calls are not allowed inside
+a list comprehension whose result type is `Iter`.
+
+An `Iter` comprehension is lazy: its body runs later, when the iterator is
+consumed. Control-flow operations that jump out of the surrounding function or
+loop, or calls that need immediate error propagation, cannot be preserved safely
+across that lazy boundary.
+
+## Erroneous example
+
+```{literalinclude} /sources/error_codes/4211_error/top.mbt
+:language: moonbit
+```
+
+## Suggestion
+
+Keep the comprehension body as a normal value-producing expression. If you need
+early exit, use an eager collection target or write an explicit loop around the
+iterator consumption.
+
+```{literalinclude} /sources/error_codes/4211_fixed/top.mbt
+:language: moonbit
+```

--- a/next/locales/ja/LC_MESSAGES/language/error_codes/E4120.po
+++ b/next/locales/ja/LC_MESSAGES/language/error_codes/E4120.po
@@ -1,0 +1,68 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026, International Digital Economy Academy
+# This file is distributed under the same license as the MoonBit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MoonBit \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-12 10:17+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../language/error_codes/E4120.md:1
+msgid "E4120"
+msgstr "E4120"
+
+#: ../../language/error_codes/E4120.md:3
+msgid "Compiler diagnostic name: `unhandled_error`."
+msgstr "コンパイラ診断名：`unhandled_error`。"
+
+#: ../../language/error_codes/E4120.md:5
+msgid ""
+"An infix operator application may raise an error, but the error is not "
+"handled."
+msgstr ""
+"中置演算子の適用がエラーを送出する可能性がありますが、そのエラーが処理されて"
+"いません。"
+
+#: ../../language/error_codes/E4120.md:7
+msgid ""
+"Most error-producing function calls are checked directly at the call "
+"site. This diagnostic is used for operator applications after the "
+"operator has been resolved to a function whose effect may raise. The "
+"operation must either handle the error locally or appear in a context "
+"that can propagate it."
+msgstr ""
+"エラーを発生させるほとんどの関数呼び出しは、呼び出し箇所で直接チェックされま"
+"す。この診断は、演算子がエラーを送出しうる関数へ解決された後の演算子適用に使"
+"われます。その操作は、ローカルでエラーを処理するか、そのエラーを伝播できる文"
+"脈に現れる必要があります。"
+
+#: ../../language/error_codes/E4120.md:12
+msgid ""
+"This diagnostic is currently tied to an operator-resolution path and is "
+"not monitored by a source-level error-code example."
+msgstr ""
+"この診断は現在、演算子解決の経路に結び付いており、ソースレベルのエラーコード"
+"例では監視されていません。"
+
+#: ../../language/error_codes/E4120.md:15
+msgid "Suggestion"
+msgstr "提案"
+
+#: ../../language/error_codes/E4120.md:17
+msgid ""
+"Handle the error with `try`/`catch`, or use the operator only inside a "
+"function whose signature permits the raised error."
+msgstr ""
+"`try`/`catch` でエラーを処理するか、送出されるエラーを許可するシグネチャを持"
+"つ関数の中でのみ、その演算子を使用してください。"

--- a/next/locales/ja/LC_MESSAGES/language/error_codes/E4198.po
+++ b/next/locales/ja/LC_MESSAGES/language/error_codes/E4198.po
@@ -1,0 +1,69 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026, International Digital Economy Academy
+# This file is distributed under the same license as the MoonBit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MoonBit \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-12 10:17+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../language/error_codes/E4198.md:1
+msgid "E4198"
+msgstr "E4198"
+
+#: ../../language/error_codes/E4198.md:3
+msgid "Compiler diagnostic name: `struct_constr_not_implemented`."
+msgstr "コンパイラ診断名：`struct_constr_not_implemented`。"
+
+#: ../../language/error_codes/E4198.md:5
+msgid ""
+"A struct declares a constructor, but the matching constructor "
+"implementation is missing or is not a regular implementation of that "
+"constructor."
+msgstr ""
+"構造体がコンストラクタを宣言していますが、対応するコンストラクタ実装が存在し"
+"ないか、そのコンストラクタの通常の実装ではありません。"
+
+#: ../../language/error_codes/E4198.md:8
+msgid ""
+"Struct constructor declarations and implementations must agree on the "
+"same constructor function. An alias or trait implementation is not enough"
+" to satisfy the declaration."
+msgstr ""
+"構造体コンストラクタの宣言と実装は、同じコンストラクタ関数を指している必要が"
+"あります。エイリアスや trait 実装だけでは、この宣言を満たすには不十分です。"
+
+#: ../../language/error_codes/E4198.md:12
+msgid ""
+"This diagnostic is produced by the struct-constructor consistency "
+"checker. The legacy declaration form that reaches this checker is "
+"currently rejected earlier by the parser/deprecation diagnostics, so this"
+" page is not monitored by a source-level error-code example."
+msgstr ""
+"この診断は、構造体コンストラクタの一貫性チェッカによって生成されます。この"
+"チェッカに到達する古い宣言形式は、現在はより早い段階でパーサまたは非推奨診断"
+"により拒否されるため、このページはソースレベルのエラーコード例では監視されて"
+"いません。"
+
+#: ../../language/error_codes/E4198.md:17
+msgid "Suggestion"
+msgstr "提案"
+
+#: ../../language/error_codes/E4198.md:19
+msgid ""
+"Define the constructor as the regular struct constructor function, and "
+"make its parameter list and return type match the declaration."
+msgstr ""
+"コンストラクタを通常の構造体コンストラクタ関数として定義し、そのパラメータリ"
+"ストと戻り値の型を宣言に一致させてください。"

--- a/next/locales/ja/LC_MESSAGES/language/error_codes/E4201.po
+++ b/next/locales/ja/LC_MESSAGES/language/error_codes/E4201.po
@@ -1,0 +1,69 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026, International Digital Economy Academy
+# This file is distributed under the same license as the MoonBit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MoonBit \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-12 10:17+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../language/error_codes/E4201.md:1
+msgid "E4201"
+msgstr "E4201"
+
+#: ../../language/error_codes/E4201.md:3
+msgid "Compiler diagnostic name: `struct_constr_inconsistent_impl`."
+msgstr "コンパイラ診断名：`struct_constr_inconsistent_impl`。"
+
+#: ../../language/error_codes/E4201.md:5
+msgid ""
+"A struct constructor implementation has an inconsistent type compared "
+"with the constructor declaration on the struct."
+msgstr ""
+"構造体コンストラクタの実装の型が、その構造体上のコンストラクタ宣言と一致して"
+"いません。"
+
+#: ../../language/error_codes/E4201.md:8
+msgid ""
+"The constructor's parameter arity, type parameters, effects, and return "
+"type must match the declaration. In particular, a constructor for `struct"
+" T` must construct `T` with the declared signature."
+msgstr ""
+"コンストラクタのパラメータ数、型パラメータ、効果、戻り値の型は、宣言と一致し"
+"ている必要があります。特に、`struct T` のコンストラクタは、宣言されたシグネ"
+"チャで `T` を構築しなければなりません。"
+
+#: ../../language/error_codes/E4201.md:12
+msgid ""
+"This diagnostic is produced by the struct-constructor consistency "
+"checker. The legacy declaration form that reaches this checker is "
+"currently rejected earlier by the parser/deprecation diagnostics, so this"
+" page is not monitored by a source-level error-code example."
+msgstr ""
+"この診断は、構造体コンストラクタの一貫性チェッカによって生成されます。この"
+"チェッカに到達する古い宣言形式は、現在はより早い段階でパーサまたは非推奨診断"
+"により拒否されるため、このページはソースレベルのエラーコード例では監視されて"
+"いません。"
+
+#: ../../language/error_codes/E4201.md:17
+msgid "Suggestion"
+msgstr "提案"
+
+#: ../../language/error_codes/E4201.md:19
+msgid ""
+"Update either the constructor declaration or the implementation so both "
+"sides describe the same function type."
+msgstr ""
+"コンストラクタ宣言または実装のどちらかを更新し、両方が同じ関数型を表すように"
+"してください。"

--- a/next/locales/ja/LC_MESSAGES/language/error_codes/E4211.po
+++ b/next/locales/ja/LC_MESSAGES/language/error_codes/E4211.po
@@ -1,0 +1,85 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026, International Digital Economy Academy
+# This file is distributed under the same license as the MoonBit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MoonBit \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-12 10:17+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../language/error_codes/E4211.md:1
+msgid "E4211"
+msgstr "E4211"
+
+#: ../../language/error_codes/E4211.md:3
+msgid "Compiler diagnostic name: `control_in_list_comprehension`."
+msgstr "コンパイラ診断名：`control_in_list_comprehension`。"
+
+#: ../../language/error_codes/E4211.md:5
+msgid ""
+"`return`, `break`, `continue`, and error-producing calls are not allowed "
+"inside a list comprehension whose result type is `Iter`."
+msgstr ""
+"結果の型が `Iter` であるリスト内包表記の内部では、`return`、`break`、"
+"`continue`、およびエラーを発生させる呼び出しは使用できません。"
+
+#: ../../language/error_codes/E4211.md:8
+msgid ""
+"An `Iter` comprehension is lazy: its body runs later, when the iterator "
+"is consumed. Control-flow operations that jump out of the surrounding "
+"function or loop, or calls that need immediate error propagation, cannot "
+"be preserved safely across that lazy boundary."
+msgstr ""
+"`Iter` の内包表記は遅延評価されます。本体は後で、イテレータが消費されるとき"
+"に実行されます。外側の関数やループから脱出する制御フロー操作や、即時のエラー"
+"伝播を必要とする呼び出しは、この遅延境界を越えて安全に保持できません。"
+
+#: ../../language/error_codes/E4211.md:13
+msgid "Erroneous example"
+msgstr "エラー例"
+
+#: ../../language/error_codes/E4211.md:15
+msgid ""
+"fn values() -> Iter[Int] {\n"
+"  let xs : Iter[Int] = [ for _ in 0..<3 => { return Iter::empty() } ]\n"
+"  xs\n"
+"}\n"
+msgstr ""
+
+#: ../../language/error_codes/E4211.md:19
+msgid "Suggestion"
+msgstr "提案"
+
+#: ../../language/error_codes/E4211.md:21
+msgid ""
+"Keep the comprehension body as a normal value-producing expression. If "
+"you need early exit, use an eager collection target or write an explicit "
+"loop around the iterator consumption."
+msgstr ""
+"内包表記の本体は、通常の値を生成する式のままにしてください。早期終了が必要な"
+"場合は、即時評価されるコレクションを対象にするか、イテレータを消費する箇所で"
+"明示的なループを書いてください。"
+
+#: ../../language/error_codes/E4211.md:25
+msgid ""
+"fn values() -> Iter[Int] {\n"
+"  [ for i in 0..<3 => i ]\n"
+"}\n"
+"\n"
+"test {\n"
+"  let mut sum = 0\n"
+"  values().each(x => sum = sum + x)\n"
+"  inspect(sum, content=\"3\")\n"
+"}\n"
+msgstr ""

--- a/next/locales/zh_CN/LC_MESSAGES/language/error_codes/E4120.po
+++ b/next/locales/zh_CN/LC_MESSAGES/language/error_codes/E4120.po
@@ -1,0 +1,65 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026, International Digital Economy Academy
+# This file is distributed under the same license as the MoonBit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MoonBit \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-12 10:17+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../language/error_codes/E4120.md:1
+msgid "E4120"
+msgstr "E4120"
+
+#: ../../language/error_codes/E4120.md:3
+msgid "Compiler diagnostic name: `unhandled_error`."
+msgstr "编译器诊断名称：`unhandled_error`。"
+
+#: ../../language/error_codes/E4120.md:5
+msgid ""
+"An infix operator application may raise an error, but the error is not "
+"handled."
+msgstr ""
+"中缀运算符应用可能会抛出错误，但该错误没有被处理。"
+
+#: ../../language/error_codes/E4120.md:7
+msgid ""
+"Most error-producing function calls are checked directly at the call "
+"site. This diagnostic is used for operator applications after the "
+"operator has been resolved to a function whose effect may raise. The "
+"operation must either handle the error locally or appear in a context "
+"that can propagate it."
+msgstr ""
+"大多数会产生错误的函数调用会在调用点直接检查。该诊断用于运算符应用：当运算"
+"符被解析为一个可能抛出错误的函数后，如果该操作既没有在本地处理错误，也没有"
+"出现在可以传播该错误的上下文中，就会触发该诊断。"
+
+#: ../../language/error_codes/E4120.md:12
+msgid ""
+"This diagnostic is currently tied to an operator-resolution path and is "
+"not monitored by a source-level error-code example."
+msgstr ""
+"该诊断目前绑定在运算符解析路径上，尚未由源码级错误代码示例监测。"
+
+#: ../../language/error_codes/E4120.md:15
+msgid "Suggestion"
+msgstr "建议"
+
+#: ../../language/error_codes/E4120.md:17
+msgid ""
+"Handle the error with `try`/`catch`, or use the operator only inside a "
+"function whose signature permits the raised error."
+msgstr ""
+"使用 `try`/`catch` 处理错误，或只在函数签名允许传播该错误的函数内部使用该运"
+"算符。"

--- a/next/locales/zh_CN/LC_MESSAGES/language/error_codes/E4198.po
+++ b/next/locales/zh_CN/LC_MESSAGES/language/error_codes/E4198.po
@@ -1,0 +1,66 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026, International Digital Economy Academy
+# This file is distributed under the same license as the MoonBit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MoonBit \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-12 10:17+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../language/error_codes/E4198.md:1
+msgid "E4198"
+msgstr "E4198"
+
+#: ../../language/error_codes/E4198.md:3
+msgid "Compiler diagnostic name: `struct_constr_not_implemented`."
+msgstr "编译器诊断名称：`struct_constr_not_implemented`。"
+
+#: ../../language/error_codes/E4198.md:5
+msgid ""
+"A struct declares a constructor, but the matching constructor "
+"implementation is missing or is not a regular implementation of that "
+"constructor."
+msgstr ""
+"结构体声明了构造器，但缺少匹配的构造器实现，或对应实现不是该构造器的常规实"
+"现。"
+
+#: ../../language/error_codes/E4198.md:8
+msgid ""
+"Struct constructor declarations and implementations must agree on the "
+"same constructor function. An alias or trait implementation is not enough"
+" to satisfy the declaration."
+msgstr ""
+"结构体构造器的声明和实现必须对应同一个构造函数。别名或 trait 实现不足以满足"
+"该声明。"
+
+#: ../../language/error_codes/E4198.md:12
+msgid ""
+"This diagnostic is produced by the struct-constructor consistency "
+"checker. The legacy declaration form that reaches this checker is "
+"currently rejected earlier by the parser/deprecation diagnostics, so this"
+" page is not monitored by a source-level error-code example."
+msgstr ""
+"该诊断由结构体构造器一致性检查器产生。能够到达该检查器的旧式声明形式目前会"
+"更早被解析器或废弃语法诊断拒绝，因此本页面尚未由源码级错误代码示例监测。"
+
+#: ../../language/error_codes/E4198.md:17
+msgid "Suggestion"
+msgstr "建议"
+
+#: ../../language/error_codes/E4198.md:19
+msgid ""
+"Define the constructor as the regular struct constructor function, and "
+"make its parameter list and return type match the declaration."
+msgstr ""
+"将构造器定义为常规结构体构造函数，并让它的参数列表和返回类型与声明一致。"

--- a/next/locales/zh_CN/LC_MESSAGES/language/error_codes/E4201.po
+++ b/next/locales/zh_CN/LC_MESSAGES/language/error_codes/E4201.po
@@ -1,0 +1,64 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026, International Digital Economy Academy
+# This file is distributed under the same license as the MoonBit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MoonBit \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-12 10:17+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../language/error_codes/E4201.md:1
+msgid "E4201"
+msgstr "E4201"
+
+#: ../../language/error_codes/E4201.md:3
+msgid "Compiler diagnostic name: `struct_constr_inconsistent_impl`."
+msgstr "编译器诊断名称：`struct_constr_inconsistent_impl`。"
+
+#: ../../language/error_codes/E4201.md:5
+msgid ""
+"A struct constructor implementation has an inconsistent type compared "
+"with the constructor declaration on the struct."
+msgstr ""
+"结构体构造器实现的类型与结构体上的构造器声明不一致。"
+
+#: ../../language/error_codes/E4201.md:8
+msgid ""
+"The constructor's parameter arity, type parameters, effects, and return "
+"type must match the declaration. In particular, a constructor for `struct"
+" T` must construct `T` with the declared signature."
+msgstr ""
+"构造器的参数数量、类型参数、效果以及返回类型都必须与声明匹配。特别是，"
+"`struct T` 的构造器必须按照声明的签名构造 `T`。"
+
+#: ../../language/error_codes/E4201.md:12
+msgid ""
+"This diagnostic is produced by the struct-constructor consistency "
+"checker. The legacy declaration form that reaches this checker is "
+"currently rejected earlier by the parser/deprecation diagnostics, so this"
+" page is not monitored by a source-level error-code example."
+msgstr ""
+"该诊断由结构体构造器一致性检查器产生。能够到达该检查器的旧式声明形式目前会"
+"更早被解析器或废弃语法诊断拒绝，因此本页面尚未由源码级错误代码示例监测。"
+
+#: ../../language/error_codes/E4201.md:17
+msgid "Suggestion"
+msgstr "建议"
+
+#: ../../language/error_codes/E4201.md:19
+msgid ""
+"Update either the constructor declaration or the implementation so both "
+"sides describe the same function type."
+msgstr ""
+"更新构造器声明或实现，使两者描述同一个函数类型。"

--- a/next/locales/zh_CN/LC_MESSAGES/language/error_codes/E4211.po
+++ b/next/locales/zh_CN/LC_MESSAGES/language/error_codes/E4211.po
@@ -1,0 +1,84 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026, International Digital Economy Academy
+# This file is distributed under the same license as the MoonBit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MoonBit \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-12 10:17+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../language/error_codes/E4211.md:1
+msgid "E4211"
+msgstr "E4211"
+
+#: ../../language/error_codes/E4211.md:3
+msgid "Compiler diagnostic name: `control_in_list_comprehension`."
+msgstr "编译器诊断名称：`control_in_list_comprehension`。"
+
+#: ../../language/error_codes/E4211.md:5
+msgid ""
+"`return`, `break`, `continue`, and error-producing calls are not allowed "
+"inside a list comprehension whose result type is `Iter`."
+msgstr ""
+"在结果类型为 `Iter` 的列表推导式内部，不允许使用 `return`、`break`、"
+"`continue`，也不允许调用会产生错误的函数。"
+
+#: ../../language/error_codes/E4211.md:8
+msgid ""
+"An `Iter` comprehension is lazy: its body runs later, when the iterator "
+"is consumed. Control-flow operations that jump out of the surrounding "
+"function or loop, or calls that need immediate error propagation, cannot "
+"be preserved safely across that lazy boundary."
+msgstr ""
+"`Iter` 推导式是惰性的：它的主体会在之后迭代器被消费时才运行。会跳出外围函数"
+"或循环的控制流操作，以及需要立即传播错误的调用，都无法安全地跨越这个惰性边"
+"界。"
+
+#: ../../language/error_codes/E4211.md:13
+msgid "Erroneous example"
+msgstr "错误示例"
+
+#: ../../language/error_codes/E4211.md:15
+msgid ""
+"fn values() -> Iter[Int] {\n"
+"  let xs : Iter[Int] = [ for _ in 0..<3 => { return Iter::empty() } ]\n"
+"  xs\n"
+"}\n"
+msgstr ""
+
+#: ../../language/error_codes/E4211.md:19
+msgid "Suggestion"
+msgstr "建议"
+
+#: ../../language/error_codes/E4211.md:21
+msgid ""
+"Keep the comprehension body as a normal value-producing expression. If "
+"you need early exit, use an eager collection target or write an explicit "
+"loop around the iterator consumption."
+msgstr ""
+"让推导式主体保持为普通的产值表达式。如果需要提前退出，请使用急切求值的集合"
+"目标，或在消费迭代器时编写显式循环。"
+
+#: ../../language/error_codes/E4211.md:25
+msgid ""
+"fn values() -> Iter[Int] {\n"
+"  [ for i in 0..<3 => i ]\n"
+"}\n"
+"\n"
+"test {\n"
+"  let mut sum = 0\n"
+"  values().each(x => sum = sum + x)\n"
+"  inspect(sum, content=\"3\")\n"
+"}\n"
+msgstr ""

--- a/next/sources/error_codes/4211_error/moon.mod.json
+++ b/next/sources/error_codes/4211_error/moon.mod.json
@@ -1,0 +1,1 @@
+{"name": "moonbit-community/E4211"}

--- a/next/sources/error_codes/4211_error/moon.pkg.json
+++ b/next/sources/error_codes/4211_error/moon.pkg.json
@@ -1,0 +1,3 @@
+{
+  "warn-list": "-unused_value"
+}

--- a/next/sources/error_codes/4211_error/top.mbt
+++ b/next/sources/error_codes/4211_error/top.mbt
@@ -1,0 +1,4 @@
+fn values() -> Iter[Int] {
+  let xs : Iter[Int] = [ for _ in 0..<3 => { return Iter::empty() } ]
+  xs
+}

--- a/next/sources/error_codes/4211_fixed/moon.mod.json
+++ b/next/sources/error_codes/4211_fixed/moon.mod.json
@@ -1,0 +1,1 @@
+{"name": "moonbit-community/E4211"}

--- a/next/sources/error_codes/4211_fixed/moon.pkg.json
+++ b/next/sources/error_codes/4211_fixed/moon.pkg.json
@@ -1,0 +1,3 @@
+{
+  "warn-list": "-unused_value"
+}

--- a/next/sources/error_codes/4211_fixed/top.mbt
+++ b/next/sources/error_codes/4211_fixed/top.mbt
@@ -1,0 +1,9 @@
+fn values() -> Iter[Int] {
+  [ for i in 0..<3 => i ]
+}
+
+test {
+  let mut sum = 0
+  values().each(x => sum = sum + x)
+  inspect(sum, content="3")
+}


### PR DESCRIPTION
## Why

The compiler exposes diagnostics 4120, 4198, 4201, and 4211, but the documentation did not cover them yet. This PR adds focused reference pages so users can understand what each diagnostic means and how to resolve it.

## What changed

- Added English pages for E4120, E4198, E4201, and E4211.
- Added runnable error and fixed examples for E4211, which has a stable source-level reproduction.
- Added zh_CN and ja translation catalogs for the new pages.

## Why this is correct

The descriptions are aligned with the compiler diagnostic names and the compiler test coverage. E4120, E4198, and E4201 are documented without source-level examples because their current public reproduction paths are intercepted by earlier diagnostics.

## Scope

The change is limited to the four new error-code pages, the E4211 examples, and their translation catalogs.