### PR TITLE
[codex] update tour moonpad integration and examples

### DIFF
--- a/moonbit-tour/build/build.mts
+++ b/moonbit-tour/build/build.mts
@@ -41,14 +41,14 @@ const plugin = (): esbuild.Plugin => {
 
         await fs.cp("./public", "./dist", { recursive: true });
 
-        const names = ["lsp-server.js", "moonc-worker.js", "onig.wasm"];
+        const names = ["moonc-worker.js", "onig.wasm"];
         await Promise.all(
-          names.map((name) => {
+          names.map((name) =>
             fs.copyFile(
               `./node_modules/@moonbit/moonpad-monaco/dist/${name}`,
               `./dist/${name}`,
-            );
-          }),
+            ),
+          ),
         );
 
         const template = await fs.readFile("index.html", "utf8");

--- a/moonbit-tour/package.json
+++ b/moonbit-tour/package.json
@@ -37,7 +37,7 @@
     "unist-util-visit": "^5.1.0"
   },
   "dependencies": {
-    "@moonbit/moonpad-monaco": "^0.1.202602255",
+    "@moonbit/moonpad-monaco": "^0.1.202606151",
     "monaco-editor-core": "^0.52.2"
   },
   "packageManager": "pnpm@9.15.9+sha512.68046141893c66fad01c079231128e9afb89ef87e2691d69e4d40eee228988295fd4682181bae55b58418c3a253bde65a505ec7c5f9403ece5cc3cd37dcf2531"

--- a/moonbit-tour/pnpm-lock.yaml
+++ b/moonbit-tour/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@moonbit/moonpad-monaco':
-        specifier: ^0.1.202602255
-        version: 0.1.202602255(monaco-editor-core@0.52.2)
+        specifier: ^0.1.202606151
+        version: 0.1.202606151(monaco-editor-core@0.52.2)
       monaco-editor-core:
         specifier: ^0.52.2
         version: 0.52.2
@@ -416,14 +416,11 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@moonbit/analyzer@0.1.202604291':
-    resolution: {integrity: sha512-YwhutHOkGzAUtNvsqG5/X4o+X9muBYlv3MIhJiodVnzH2HvmglKYB26ctGKW2eK/418qI9NPp3bzPH88xQxOUw==}
+  '@moonbit/moonc-worker@0.1.202606094':
+    resolution: {integrity: sha512-win38k3+rtjiwUaYM46Qmk+qU3ln9nPn47n+Sa+ec7rFMN/Ls1l9tmQ8pJmXcUIK2r9utZJoKkeC2B4aOr7kNg==}
 
-  '@moonbit/moonc-worker@0.1.202604291':
-    resolution: {integrity: sha512-M0ZPApdcJ4SCre0Mq6yp/feVJ6+MyaSsk5xUaSpUh/wstzNafaByBKP65jQ4HS00QI/0Z4Mzlx26JfSaepZ6YA==}
-
-  '@moonbit/moonpad-monaco@0.1.202602255':
-    resolution: {integrity: sha512-RxSLivsbRy5DQCRaGMKydLZrXDl2Nk83sYHFs1ZPsZG9cyW6sTNpa4+5Sqzn8636scZDuUtwM6eWdh76fWm6BA==}
+  '@moonbit/moonpad-monaco@0.1.202606151':
+    resolution: {integrity: sha512-iTAERrBuYd1xNLiac42RKthH8s895E1nY2oRR/1GIarTGwMdRjjPckVtWL+8rjS5wz5fldleB1M0Z+PNbX30bw==}
     peerDependencies:
       monaco-editor-core: ^0.52.0
 
@@ -2632,20 +2629,6 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vscode-jsonrpc@8.2.0:
-    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
-    engines: {node: '>=14.0.0'}
-
-  vscode-jsonrpc@8.2.1:
-    resolution: {integrity: sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==}
-    engines: {node: '>=14.0.0'}
-
-  vscode-languageserver-protocol@3.17.5:
-    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
-
-  vscode-languageserver-types@3.17.5:
-    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
-
   vscode-oniguruma@2.0.1:
     resolution: {integrity: sha512-poJU8iHIWnC3vgphJnrLZyI3YdqRlR27xzqDmpPXYzA93R4Gk8z7T6oqDzDoHjoikA2aS82crdXFkjELCdJsjQ==}
 
@@ -2878,19 +2861,14 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@moonbit/analyzer@0.1.202604291': {}
+  '@moonbit/moonc-worker@0.1.202606094': {}
 
-  '@moonbit/moonc-worker@0.1.202604291': {}
-
-  '@moonbit/moonpad-monaco@0.1.202602255(monaco-editor-core@0.52.2)':
+  '@moonbit/moonpad-monaco@0.1.202606151(monaco-editor-core@0.52.2)':
     dependencies:
-      '@moonbit/analyzer': 0.1.202604291
-      '@moonbit/moonc-worker': 0.1.202604291
+      '@moonbit/moonc-worker': 0.1.202606094
       '@zenfs/core': 1.11.4
       comlink: 4.4.2
       monaco-editor-core: 0.52.2
-      vscode-jsonrpc: 8.2.1
-      vscode-languageserver-protocol: 3.17.5
       vscode-oniguruma: 2.0.1
       vscode-textmate: 9.3.2
       vscode-uri: 3.1.0
@@ -5573,17 +5551,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
-
-  vscode-jsonrpc@8.2.0: {}
-
-  vscode-jsonrpc@8.2.1: {}
-
-  vscode-languageserver-protocol@3.17.5:
-    dependencies:
-      vscode-jsonrpc: 8.2.0
-      vscode-languageserver-types: 3.17.5
-
-  vscode-languageserver-types@3.17.5: {}
 
   vscode-oniguruma@2.0.1: {}
 

--- a/moonbit-tour/src/editor.ts
+++ b/moonbit-tour/src/editor.ts
@@ -4,11 +4,7 @@ import * as util from "./util";
 
 const moon = moonbitMode.init({
   onigWasmUrl: new URL("./onig.wasm", import.meta.url).toString(),
-  lspWorker: new Worker("/lsp-server.js"),
   mooncWorkerFactory: () => new Worker("/moonc-worker.js"),
-  codeLensFilter(l) {
-    return l.command?.command === "moonbit-lsp/debug-main";
-  },
 });
 
 // @ts-ignore
@@ -30,27 +26,19 @@ const trace = moonbitMode.traceCommandFactory();
 
 async function run(debug: boolean) {
   if (debug) {
-    const result = await moon.compile({
-      libInputs: [["main.mbt", model.getValue()]],
+    const result = await moon.runSingleFile({
+      code: model.getValue(),
+      filename: "main.mbt",
       debugMain: true,
     });
     switch (result.kind) {
       case "success": {
-        const js = result.js;
-        const stream = await moon.run(js);
-        let buffer = "";
-        await stream.pipeTo(
-          new WritableStream({
-            write(chunk) {
-              buffer += `${chunk}\n`;
-            },
-          }),
-        );
-        output.textContent = buffer;
+        output.textContent = result.output;
         return;
       }
       case "error": {
-        console.error(result.diagnostics);
+        console.error(result.diagnostics ?? result.message);
+        output.textContent = result.message;
       }
     }
     return;

--- a/moonbit-tour/tour/chapter1_basics/lesson14_test/index.mbt
+++ b/moonbit-tour/tour/chapter1_basics/lesson14_test/index.mbt
@@ -6,7 +6,7 @@ test {
 
 test {
   inspect(fib(5))
-  inspect([1,2,3,4].map(fib))
+  inspect(to_repr([1,2,3,4].map(fib)), content="[1, 1, 2, 3]")
 }
 
 // Add test name to make it more descriptive.
@@ -22,4 +22,3 @@ fn fib(n : Int) -> Int {
     fib(n - 1) + fib(n - 2)
   }
 }
-

--- a/moonbit-tour/tour/chapter1_basics/lesson6_array/index.mbt
+++ b/moonbit-tour/tour/chapter1_basics/lesson6_array/index.mbt
@@ -8,15 +8,15 @@ fn main {
   // We can also use the spread operator to concatenate arrays.
   let arr3 = [..arr1, 1000, 2000, ..arr2, 3000, 4000]
   println("spread arrays:")
-  println(arr3)
+  println(to_repr(arr3))
 
   let view : ArrayView[Int] = arr1[1:4]
   println("array view:")
-  println(view)
+  println(to_repr(view))
   println("view[0]:")
   println(view[0])
 
   arr1.push(6) // push an element to the end
   println("updated array:")
-  println(arr1)
+  println(to_repr(arr1))
 }

--- a/moonbit-tour/tour/chapter1_basics/lesson7_tuple/index.mbt
+++ b/moonbit-tour/tour/chapter1_basics/lesson7_tuple/index.mbt
@@ -2,11 +2,11 @@ fn main {
   // create Tuple 
   let tuple = (3.14, false, [1,2,3])  
   let tuple2 : (Float, Bool, Int) = (2.1, true, 20)
-  println(tuple)
+  println(to_repr(tuple))
 
   // Accessing tuple elements
   println(tuple.0)
-  println(tuple.2)
+  println(to_repr(tuple.2))
 
   // Tuple can also be destructured. 
   let (a, b, c) = f()

--- a/moonbit-tour/tour/chapter1_basics/lesson8_map/index.mbt
+++ b/moonbit-tour/tour/chapter1_basics/lesson8_map/index.mbt
@@ -1,7 +1,7 @@
 fn main {
   // Create a map by map literal
   let map1 = { "key1": 1, "key2": 2, "key3": 3 }
-  println(map1)
+  println(to_repr(map1))
   // You can also create a map by Map::from_array, from a list of key-value pairs
   let map2 = Map::from_array([("key1", 1), ("key2", 2), ("key3", 3)])
   println(map1 == map2)
@@ -11,7 +11,7 @@ fn main {
 
   // Update a value by key
   map1["key1"] = 10
-  println(map1)
+  println(to_repr(map1))
 
   // test a if a key exists
   println(map1.contains("key1"))

--- a/moonbit-tour/tour/chapter3_pattern_matching/lesson6_alias_pattern/index.mbt
+++ b/moonbit-tour/tour/chapter3_pattern_matching/lesson6_alias_pattern/index.mbt
@@ -1,6 +1,6 @@
 fn main {
   let (a, (b, _) as tuple, _) as triple = (1, (true, 5), false)
   println("a: \{a}, b: \{b}")
-  println("tuple: \{tuple}")
-  println("triple: \{triple}")
+  println("tuple: \{to_repr(tuple)}")
+  println("triple: \{to_repr(triple)}")
 }

--- a/moonbit-tour/tour/chapter4_more_data_types/lesson2_immutable_set/index.mbt
+++ b/moonbit-tour/tour/chapter4_more_data_types/lesson2_immutable_set/index.mbt
@@ -7,5 +7,5 @@ fn main {
   let c = a.add(6)
   let d = b.add(6)
   let except_one = d.remove_min()
-  println(d)
+  println(to_repr(d))
 }

--- a/moonbit-tour/tour/chapter4_more_data_types/lesson3_immutable_map/index.mbt
+++ b/moonbit-tour/tour/chapter4_more_data_types/lesson3_immutable_map/index.mbt
@@ -3,5 +3,5 @@ fn main {
   let a = @immut/hashmap.from_array([(1, "a"), (2, "b"), (3, "c")])
   let b = a.add(4, "d")
   let c = @immut/sorted_map.from_iter(b.iter())
-  println(c.keys_as_iter().collect())
+  println(to_repr(c.keys_as_iter().collect()))
 }

--- a/moonbit-tour/tour/chapter5_methods_generics_and_traits/lesson2_local_methods/index.mbt
+++ b/moonbit-tour/tour/chapter5_methods_generics_and_traits/lesson2_local_methods/index.mbt
@@ -11,8 +11,8 @@ fn @sorted_set.SortedSet::add_range(self : Self[Int], l : Int, r : Int) -> Unit 
 
 ///|
 fn main {
-  let set = @sorted_set.new()
+  let set = @sorted_set.SortedSet([])
   set.add_range(1, 10)
   set.add_range(15, 20)
-  println(set)
+  println(to_repr(set))
 }

--- a/moonbit-tour/tour/chapter5_methods_generics_and_traits/lesson3_generic_function/index.mbt
+++ b/moonbit-tour/tour/chapter5_methods_generics_and_traits/lesson3_generic_function/index.mbt
@@ -27,16 +27,16 @@ fn main {
   // swap ints
   let array1 = [1, 2]
   swap_int(array1)
-  println(array1)
+  println(to_repr(array1))
 
   // swap bools
   let array2 = [true, false]
   swap_bool(array2)
-  println(array2)
+  println(to_repr(array2))
 
   // generic swap
   swap(array1)
   swap(array2)
-  println(array1)
-  println(array2)
+  println(to_repr(array1))
+  println(to_repr(array2))
 }

--- a/moonbit-tour/tour/zh/chapter1_basics/lesson14_test/index.mbt
+++ b/moonbit-tour/tour/zh/chapter1_basics/lesson14_test/index.mbt
@@ -6,7 +6,7 @@ test {
 
 test {
   inspect(fib(5))
-  inspect([1,2,3,4].map(fib))
+  inspect(to_repr([1,2,3,4].map(fib)), content="[1, 1, 2, 3]")
 }
 
 // Add test name to make it more descriptive.
@@ -22,4 +22,3 @@ fn fib(n : Int) -> Int {
     fib(n - 1) + fib(n - 2)
   }
 }
-

--- a/moonbit-tour/tour/zh/chapter1_basics/lesson6_array/index.mbt
+++ b/moonbit-tour/tour/zh/chapter1_basics/lesson6_array/index.mbt
@@ -8,15 +8,15 @@ fn main {
   // We can also use the spread operator to concatenate arrays.
   let arr3 = [..arr1, 1000, 2000, ..arr2, 3000, 4000]
   println("spread arrays:")
-  println(arr3)
+  println(to_repr(arr3))
 
   let view : ArrayView[Int] = arr1[1:4]
   println("array view:")
-  println(view)
+  println(to_repr(view))
   println("view[0]:")
   println(view[0])
 
   arr1.push(6) // push an element to the end
   println("updated array:")
-  println(arr1)
+  println(to_repr(arr1))
 }

--- a/moonbit-tour/tour/zh/chapter1_basics/lesson7_tuple/index.mbt
+++ b/moonbit-tour/tour/zh/chapter1_basics/lesson7_tuple/index.mbt
@@ -2,11 +2,11 @@ fn main {
   // create Tuple 
   let tuple = (3.14, false, [1,2,3])  
   let tuple2 : (Float, Bool, Int) = (2.1, true, 20)
-  println(tuple)
+  println(to_repr(tuple))
 
   // Accessing tuple elements
   println(tuple.0)
-  println(tuple.2)
+  println(to_repr(tuple.2))
 
   // Tuple can also be destructured. 
   let (a, b, c) = f()

--- a/moonbit-tour/tour/zh/chapter1_basics/lesson8_map/index.mbt
+++ b/moonbit-tour/tour/zh/chapter1_basics/lesson8_map/index.mbt
@@ -1,7 +1,7 @@
 fn main {
   // Create a map by map literal
   let map1 = { "key1": 1, "key2": 2, "key3": 3 }
-  println(map1)
+  println(to_repr(map1))
   // You can also create a map by Map::from_array, from a list of key-value pairs
   let map2 = Map::from_array([("key1", 1), ("key2", 2), ("key3", 3)])
   println(map1 == map2)
@@ -11,7 +11,7 @@ fn main {
 
   // Update a value by key
   map1["key1"] = 10
-  println(map1)
+  println(to_repr(map1))
 
   // test a if a key exists
   println(map1.contains("key1"))

--- a/moonbit-tour/tour/zh/chapter3_pattern_matching/lesson6_alias_pattern/index.mbt
+++ b/moonbit-tour/tour/zh/chapter3_pattern_matching/lesson6_alias_pattern/index.mbt
@@ -1,6 +1,6 @@
 fn main {
   let (a, (b, _) as tuple, _) as triple = (1, (true, 5), false)
   println("a: \{a}, b: \{b}")
-  println("tuple: \{tuple}")
-  println("triple: \{triple}")
+  println("tuple: \{to_repr(tuple)}")
+  println("triple: \{to_repr(triple)}")
 }

--- a/moonbit-tour/tour/zh/chapter4_more_data_types/lesson2_immutable_set/index.mbt
+++ b/moonbit-tour/tour/zh/chapter4_more_data_types/lesson2_immutable_set/index.mbt
@@ -7,5 +7,5 @@ fn main {
   let c = a.add(6)
   let d = b.add(6)
   let except_one = d.remove_min()
-  println(d)
+  println(to_repr(d))
 }

--- a/moonbit-tour/tour/zh/chapter4_more_data_types/lesson3_immutable_map/index.mbt
+++ b/moonbit-tour/tour/zh/chapter4_more_data_types/lesson3_immutable_map/index.mbt
@@ -3,5 +3,5 @@ fn main {
   let a = @immut/hashmap.from_array([(1, "a"), (2, "b"), (3, "c")])
   let b = a.add(4, "d")
   let c = @immut/sorted_map.from_iter(b.iter())
-  println(c.keys_as_iter().collect())
+  println(to_repr(c.keys_as_iter().collect()))
 }

--- a/moonbit-tour/tour/zh/chapter5_methods_generics_and_traits/lesson2_local_methods/index.mbt
+++ b/moonbit-tour/tour/zh/chapter5_methods_generics_and_traits/lesson2_local_methods/index.mbt
@@ -11,8 +11,8 @@ fn @sorted_set.SortedSet::add_range(self : Self[Int], l : Int, r : Int) -> Unit 
 
 ///|
 fn main {
-  let set = @sorted_set.new()
+  let set = @sorted_set.SortedSet([])
   set.add_range(1, 10)
   set.add_range(15, 20)
-  println(set)
+  println(to_repr(set))
 }

--- a/moonbit-tour/tour/zh/chapter5_methods_generics_and_traits/lesson3_generic_function/index.mbt
+++ b/moonbit-tour/tour/zh/chapter5_methods_generics_and_traits/lesson3_generic_function/index.mbt
@@ -27,16 +27,16 @@ fn main {
   // swap ints
   let array1 = [1, 2]
   swap_int(array1)
-  println(array1)
+  println(to_repr(array1))
 
   // swap bools
   let array2 = [true, false]
   swap_bool(array2)
-  println(array2)
+  println(to_repr(array2))
 
   // generic swap
   swap(array1)
   swap(array2)
-  println(array1)
-  println(array2)
+  println(to_repr(array1))
+  println(to_repr(array2))
 }


### PR DESCRIPTION
## Summary

- Update the tour app to use the latest `@moonbit/moonpad-monaco` integration and single-file runtime API.
- Remove obsolete LSP worker wiring and copied asset handling.
- Update English and Chinese tour examples to avoid deprecated `Show`-based structured printing and deprecated `@sorted_set.new()` usage.

## Why

The newer moonpad Monaco package no longer ships the old LSP worker path and exposes `runSingleFile` for execution. The updated compiler also reports deprecated structured-value printing and `SortedSet::new()` usage in tour examples, so the examples need to use `to_repr(...)` and `@sorted_set.SortedSet([])` instead.

## Validation

- `just tour-build`
- `git diff --check`
- Scanned all `moonbit-tour/tour/**/index.mbt` files with `moon check --target js --output-json` and confirmed `deprecatedCount: 0` and `sortedSetDeprecatedCount: 0`.