### PR TITLE
fix: sample code comment 

### DIFF
--- a/next/sources/language/src/operator/top.mbt
+++ b/next/sources/language/src/operator/top.mbt
@@ -61,7 +61,7 @@ fn pipe() -> Unit {
   1
   |> add(5) // <=> add(1, 5)
   |> x => { x + 1 }
-  |> ignore // <=> ignore(add(1, 5))
+  |> ignore // <=> ignore(add(1, 5) + 1)
   // end operator 4
 }
 


### PR DESCRIPTION
fix sample code comment 

`ignore(add(1, 5))` should be `ignore(add(1, 5) + 1)`