### PR TITLE
fix: correct MoonBit syntax highlighting

### DIFF
--- a/next/_ext/lexer.py
+++ b/next/_ext/lexer.py
@@ -19,7 +19,7 @@ class MoonBitLexer(RegexLexer):
         'root': [
             (r"#.*$", token.Comment.Preproc),
             (r"//.*$", token.Comment.Single),
-            (r"b?\'.*\'", token.Literal),
+            (r"b?'(?:\\(?:[0\\tnrb\"']|x[0-9a-fA-F]{2}|u\{[0-9a-fA-F]+\}|u[0-9a-fA-F]{4})|[^\\'\n])+'", token.Literal),
             (r"#\|.*$", token.String),
             (r"(b)(\")", bygroups(token.String.Affix, token.String), "string.inline"),
             ("\"", token.String, "string.inline"),
@@ -45,7 +45,7 @@ class MoonBitLexer(RegexLexer):
             (words(('true', 'false'), suffix=r"\b"), token.Keyword.Constant),
             (words(('Eq', 'Compare', 'Hash', 'Show', 'Default', 'ToJson', 'FromJson'), suffix=r"\b"), token.Name.Builtin),
             (words(('Array', 'FixedArray', 'Int', 'Int64', 'UInt', 'UInt64', 'Option', 'Result', 'Byte', 'Bool', 'Unit', 'String', 'Float', 'Double'), suffix=r"\b"), token.Name.Builtin),
-            (words(('+', '-', '*', '/', '%', '|>', '>>', '<<', '&&', '||', '&', '|', '<', '>', '==')), token.Operator),
+            (r"\|>|>>|<<|&&|\|\||==|!=|<=|>=|[+\-*/%&|<>]", token.Operator),
             (words(('not', 'lsl', 'lsr', 'asr', 'op_add', 'op_sub', 'op_div', 'op_mul', 'op_mod', '...')), token.Operator.Word),
             # @namespace.
             (r"@[A-Za-z][A-Za-z0-9_/]*\.", token.Name.Namespace),

--- a/next/conf.py
+++ b/next/conf.py
@@ -49,6 +49,9 @@ smartquotes_excludes = {
   'builders': ['man', 'text', 'markdown', 'latex'],
 }
 
+# Avoid guess-highlighting output blocks and other snippets without a language.
+highlight_language = 'none'
+
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 


### PR DESCRIPTION
## Summary

- make MoonBit character literals stop at the matching quote so comments after literals are highlighted correctly
- tokenize `<=`, `>=`, and `!=` as operators instead of splitting them into punctuation
- disable guessed highlighting for language-unspecified output blocks

## Root cause

The custom MoonBit Pygments lexer used a greedy character-literal regexp, so a line like `assert_eq(b, 'h') // 'h' ...` was consumed through the quote in the comment. Also, Sphinx guessed a default lexer for output blocks without an explicit language, which highlighted plain output such as numbers and email-like text.

## Screenshots

Compact before/after comparison across the affected cases:

<img src="https://gist.githubusercontent.com/ubugeeei/cdbe93ccf6ca6254a3db231844952efb/raw/highlight-comparison.jpg" width="780" alt="Before and after comparison of MoonBit docs syntax highlighting fixes">

## Validation

- `git show --check --stat --oneline HEAD`
- `cd next && make html SPHINXBUILD=/tmp/moonbit-docs-sphinx-venv/bin/sphinx-build`

Note: `uv` was not available on PATH in this local shell, so the Sphinx build used a temporary venv at `/tmp/moonbit-docs-sphinx-venv` with `next/requirements.txt`. The build succeeded with existing download-summary warnings.
