### PR TITLE
feat: add grammar extension and document some lexical convention 

### DIFF
--- a/next/_ext/grammar.py
+++ b/next/_ext/grammar.py
@@ -1,0 +1,172 @@
+import re
+from typing import Any
+
+from docutils import nodes
+from sphinx import addnodes
+from sphinx.application import Sphinx
+from sphinx.util.docutils import SphinxDirective
+from sphinx.util.nodes import make_id
+from sphinx.util.typing import ExtensionMetadata
+
+
+_PRODUCTION_RE = re.compile(r"^\s*([A-Za-z][A-Za-z0-9-]*)\s*::=\s*(.*)$")
+_CONTINUATION_RE = re.compile(r"^(\s+)(\S.*)$")
+_PART_RE = re.compile(r'"(?:\\.|[^"\\])*"|`(?:~?[\w-]+:)?[\w-]+`')
+
+
+class GrammarNode(nodes.General, nodes.Body, nodes.FixedTextElement):
+    pass
+
+
+def _visit_grammar_html(translator: Any, node: GrammarNode) -> None:
+    translator.body.append(translator.starttag(node, "pre", suffix=""))
+
+
+def _depart_grammar_html(translator: Any, node: GrammarNode) -> None:
+    translator.body.append("</pre>\n")
+
+
+def _visit_grammar_literal(translator: Any, node: GrammarNode) -> None:
+    translator.visit_literal_block(node)
+
+
+def _depart_grammar_literal(translator: Any, node: GrammarNode) -> None:
+    translator.depart_literal_block(node)
+
+
+class MoonBitGrammar(SphinxDirective):
+    """Render linked grammar productions from a MyST directive body."""
+
+    has_content = True
+    required_arguments = 0
+    optional_arguments = 1
+    final_argument_whitespace = False
+
+    def run(self) -> list[nodes.Node]:
+        group = self.arguments[0] if self.arguments else ""
+        domain = self.env.domains.standard_domain
+        grammar = GrammarNode(
+            "\n".join(self.content),
+            classes=[
+                "moonbit-grammar",
+                "notranslate",
+                "literal-block",
+            ],
+        )
+        grammar["translatable"] = False
+        self.set_source_info(grammar)
+
+        has_production = False
+        for offset, line in enumerate(self.content):
+            if not line.strip():
+                if grammar.children:
+                    grammar += nodes.Text("\n")
+                continue
+
+            match = _PRODUCTION_RE.match(line)
+            if match:
+                name, definition = match.groups()
+                prefix = f"grammar-token-{group}" if group else "grammar-token"
+                node_id = make_id(self.env, self.state.document, prefix, name)
+                production_name = nodes.strong(
+                    name, name, classes=["grammar-production"]
+                )
+                production_name["ids"].append(node_id)
+                self.state.document.note_implicit_target(
+                    production_name, production_name
+                )
+                object_name = f"{group}:{name}" if group else name
+                domain.note_object(
+                    "token", object_name, node_id, location=grammar
+                )
+                grammar += production_name
+                grammar += nodes.Text(" ::= ")
+                grammar.extend(self._parse_definition(definition, group))
+                grammar += nodes.Text("\n")
+                has_production = True
+                continue
+
+            match = _CONTINUATION_RE.match(line)
+            if match and has_production:
+                indentation, definition = match.groups()
+                grammar += nodes.Text(indentation)
+                grammar.extend(self._parse_definition(definition, group))
+                grammar += nodes.Text("\n")
+                continue
+
+            line_number = self.content_offset + offset + 1
+            raise self.error(
+                "grammar lines must use 'name ::= definition' or an indented "
+                "continuation "
+                f"(line {line_number})"
+            )
+
+        if not has_production:
+            raise self.error("moonbit-grammar requires at least one production")
+        return [grammar]
+
+    def _parse_definition(self, definition: str, group: str) -> list[nodes.Node]:
+        result: list[nodes.Node] = []
+        position = 0
+        for match in _PART_RE.finditer(definition):
+            self._append_meta(result, definition[position : match.start()])
+            part = match.group(0)
+            if part.startswith('"'):
+                terminal = re.sub(r'\\(["\\])', r"\1", part[1:-1])
+                result.append(
+                    nodes.inline(
+                        part, terminal, classes=["grammar-terminal"]
+                    )
+                )
+            else:
+                result.append(self._nonterminal(part[1:-1], group))
+            position = match.end()
+
+        self._append_meta(result, definition[position:])
+        return result
+
+    def _nonterminal(self, name: str, group: str) -> addnodes.pending_xref:
+        target = name.lstrip("~")
+        if ":" in target:
+            display = target.split(":", 1)[1] if name.startswith("~") else target
+        else:
+            display = target
+            target = f"{group}:{target}" if group else target
+
+        reference = addnodes.pending_xref(
+            "",
+            refdomain="std",
+            reftype="token",
+            reftarget=target,
+            refwarn=False,
+        )
+        reference += nodes.emphasis(
+            name, display, classes=["grammar-nonterminal"]
+        )
+        return reference
+
+    @staticmethod
+    def _append_meta(result: list[nodes.Node], value: str) -> None:
+        if value:
+            result.append(
+                nodes.inline(value, value, classes=["grammar-meta"])
+            )
+
+
+def setup(app: Sphinx) -> ExtensionMetadata:
+    app.add_node(
+        GrammarNode,
+        html=(_visit_grammar_html, _depart_grammar_html),
+        latex=(_visit_grammar_literal, _depart_grammar_literal),
+        text=(_visit_grammar_literal, _depart_grammar_literal),
+        man=(_visit_grammar_literal, _depart_grammar_literal),
+        texinfo=(_visit_grammar_literal, _depart_grammar_literal),
+        markdown=(_visit_grammar_literal, _depart_grammar_literal),
+    )
+    app.add_directive("moonbit-grammar", MoonBitGrammar)
+    app.add_css_file("grammar.css")
+    return {
+        "version": "0.1.0",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/next/_static/grammar.css
+++ b/next/_static/grammar.css
@@ -1,0 +1,8 @@
+.moonbit-grammar .grammar-terminal {
+  color: #00622f;
+  font-weight: 600;
+}
+
+html[data-theme="dark"] .moonbit-grammar .grammar-terminal {
+  color: #abe338;
+}

--- a/next/conf.py
+++ b/next/conf.py
@@ -40,7 +40,7 @@ import sys
 from pathlib import Path
 sys.path.append(str(Path("_ext").resolve()))
 
-extensions = ['myst_parser', 'lexer', 'check', 'indent', 'sphinx_copybutton', 'sphinx_design']
+extensions = ['myst_parser', 'lexer', 'grammar', 'check', 'indent', 'sphinx_copybutton', 'sphinx_design']
 
 templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', ".env", '.venv', "README*.md", 'sources', 'download']
@@ -53,7 +53,7 @@ smartquotes_excludes = {
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = 'sphinx_book_theme'
-# html_static_path = ['_static']
+html_static_path = ['_static']
 html_theme_options = {
     "repository_url": "https://github.com/moonbitlang/moonbit-docs/",
     "path_to_docs": "next",

--- a/next/language/index.md
+++ b/next/language/index.md
@@ -34,5 +34,6 @@ attributes
 ffi
 async-experimental
 verification
+lexical-conventions
 error_codes/index
 ```

--- a/next/language/lexical-conventions.md
+++ b/next/language/lexical-conventions.md
@@ -1,0 +1,146 @@
+# Lexical Conventions
+
+```{warning}
+This page is a work in progress and is currently incomplete.
+```
+
+This page specifies MoonBit lexical forms. Runtime representation, APIs, and
+literal overloading are covered in
+[Fundamentals](fundamentals.md#built-in-data-structures).
+
+In the productions, `{ symbol }` means zero or more repetitions,
+`{ symbol }+` means one or more repetitions, and `x ... y` denotes an inclusive
+range.
+
+## Common Lexical Classes
+
+```{moonbit-grammar} moonbit-lexical
+hex-digit ::= "0" ... "9" | "A" ... "F" | "a" ... "f"
+
+octal-digit ::= "0" ... "7"
+
+unicode-scalar-value ::= "U+0000" ... "U+D7FF" | "U+E000" ... "U+10FFFF"
+
+newline ::= "LF" | "CR" | "CR" "LF" | "U+2028" | "U+2029"
+
+whitespace ::= "U+0009" | "U+000B" | "U+000C" | "U+0020" | "U+00A0" | "U+1680"
+             | "U+2000" ... "U+200A" | "U+202F" | "U+205F" | "U+3000" | "U+FEFF"
+```
+
+## String Literals
+
+```{moonbit-grammar} moonbit-lexical
+string-literal ::= "\"" { `string-character` } "\""
+
+string-character ::= `regular-string-character`
+                   | `simple-escape-sequence`
+                   | `unicode-escape-sequence`
+                   | `interpolation`
+
+regular-string-character ::= `unicode-scalar-value` except "\"", "\\", "CR", and "LF"
+
+simple-escape-sequence ::= "\\" ("\\" | "\"" | "'" | "n" | "t" | "b" | "r" | "f" | "/")
+
+unicode-escape-sequence ::= "\\u" `hex-digit` `hex-digit` `hex-digit` `hex-digit`
+                          | "\\u{" { `hex-digit` }+ "}"
+```
+
+The simple escape sequences have the following meanings:
+
+| Sequence | Character |
+| --- | --- |
+| `\\` | Backslash (U+005C) |
+| `\"` | Double quote (U+0022) |
+| `\'` | Single quote (U+0027) |
+| `\/` | Forward slash (U+002F) |
+| `\n` | Line feed (U+000A) |
+| `\r` | Carriage return (U+000D) |
+| `\t` | Horizontal tab (U+0009) |
+| `\b` | Backspace (U+0008) |
+| `\f` | Form feed (U+000C) |
+
+A Unicode escape must denote a Unicode scalar value. A CR or LF before the
+closing quote reports an unterminated string literal.
+
+### Interpolation
+
+```{moonbit-grammar} moonbit-lexical
+interpolation ::= "\\{" { `whitespace` } `expression` { `whitespace` } "}"
+```
+
+The expression must be nonempty and end at the matching `}`. Braces inside
+nested literals do not affect matching; nested interpolations are recognized
+recursively. CR, LF, `//` comments, attributes, and multiline string literals
+are not permitted.
+
+## Multiline String Literals
+
+```{moonbit-grammar} moonbit-lexical
+multiline-string-literal ::= `raw-multiline-string-literal`
+                           | `interpolated-multiline-string-literal`
+
+raw-multiline-string-literal ::= `raw-multiline-string-line`
+                               { `newline` `raw-multiline-string-line` }
+
+interpolated-multiline-string-literal ::= `interpolated-multiline-string-line`
+                                        { `newline` `interpolated-multiline-string-line` }
+
+raw-multiline-string-line ::= "#|" { `multiline-regular-character` }
+
+interpolated-multiline-string-line ::= "$|" { `multiline-regular-character` | `interpolation` }
+
+multiline-regular-character ::= `unicode-scalar-value` except "CR" and "LF"
+```
+
+The prefixes are omitted from the result, and lines are joined with U+000A. A
+final empty prefixed line adds a trailing line feed. A `#|` line is literal; in
+a `$|` line, only `\{` begins interpolation. Multiline strings are not permitted
+inside interpolation expressions.
+
+## Bytes Literals
+
+```{moonbit-grammar} moonbit-lexical
+bytes-literal ::= "b\"" { `bytes-character` } "\""
+
+bytes-character ::= `regular-string-character`
+                  | `simple-escape-sequence`
+                  | `byte-escape-sequence`
+                  | `interpolation`
+
+byte-escape-sequence ::= "\\x" `hex-digit` `hex-digit`
+                       | "\\o" ("0" ... "3") `octal-digit` `octal-digit`
+```
+
+A CR or LF before the closing quote reports an unterminated literal. Non-ASCII
+source characters contribute their UTF-8 encoding; `\xHH` and `\oDDD` each
+contribute one byte with a value from 0 to 255. Interpolation follows the
+string-literal rules. There is no multiline bytes-literal form.
+
+## Character Literals
+
+```{moonbit-grammar} moonbit-lexical
+character-literal ::= "'" `regular-character` "'"
+                    | "'" `character-escape-sequence` "'"
+
+regular-character ::= `unicode-scalar-value` except "'", "\\", "CR", and "LF"
+
+character-escape-sequence ::= `simple-escape-sequence`
+                            | `unicode-escape-sequence`
+```
+
+A character literal contains exactly one Unicode scalar value or escape
+sequence.
+
+## Byte Literals
+
+```{moonbit-grammar} moonbit-lexical
+byte-literal ::= "b'" `regular-byte-character` "'"
+               | "b'" `byte-character-escape-sequence` "'"
+
+regular-byte-character ::= "U+0000" ... "U+007F" except "'", "\\", "CR", and "LF"
+
+byte-character-escape-sequence ::= `simple-escape-sequence`
+                                 | `byte-escape-sequence`
+```
+
+An unescaped byte is ASCII. Unicode escapes are invalid in byte literals.

--- a/next/locales/zh_CN/LC_MESSAGES/language/lexical-conventions.po
+++ b/next/locales/zh_CN/LC_MESSAGES/language/lexical-conventions.po
@@ -1,0 +1,209 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026, International Digital Economy Academy
+# This file is distributed under the same license as the MoonBit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MoonBit \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-10 15:52+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../language/lexical-conventions.md:1
+msgid "Lexical Conventions"
+msgstr "词法约定"
+
+#: ../../language/lexical-conventions.md:4
+msgid "This page is a work in progress and is currently incomplete."
+msgstr "本页面仍在编写中，内容尚不完整。"
+
+#: ../../language/lexical-conventions.md:7
+msgid ""
+"This page specifies MoonBit lexical forms. Runtime representation, APIs, "
+"and literal overloading are covered in [Fundamentals]"
+"(fundamentals.md#built-in-data-structures)."
+msgstr ""
+"本页面规定 MoonBit 的词法形式。运行时表示、API 和字面量重载见[基础]"
+"(fundamentals.md#built-in-data-structures)。"
+
+#: ../../language/lexical-conventions.md:11
+msgid ""
+"In the productions, `{ symbol }` means zero or more repetitions, "
+"`{ symbol }+` means one or more repetitions, and `x ... y` denotes an "
+"inclusive range."
+msgstr ""
+"在产生式中，`{ symbol }` 表示重复零次或多次，`{ symbol }+` 表示重复一次或"
+"多次，`x ... y` 表示包含两端的范围。"
+
+#: ../../language/lexical-conventions.md:15
+msgid "Common Lexical Classes"
+msgstr "通用词法类"
+
+#: ../../language/lexical-conventions.md:30
+msgid "String Literals"
+msgstr "字符串字面量"
+
+#: ../../language/lexical-conventions.md:48
+msgid "The simple escape sequences have the following meanings:"
+msgstr "简单转义序列的含义如下："
+
+#: ../../language/lexical-conventions.md:32
+msgid "Sequence"
+msgstr "序列"
+
+#: ../../language/lexical-conventions.md:32
+msgid "Character"
+msgstr "字符"
+
+#: ../../language/lexical-conventions.md:32
+msgid "`\\\\`"
+msgstr ""
+
+#: ../../language/lexical-conventions.md:32
+msgid "Backslash (U+005C)"
+msgstr "反斜杠（U+005C）"
+
+#: ../../language/lexical-conventions.md:32
+msgid "`\\\"`"
+msgstr ""
+
+#: ../../language/lexical-conventions.md:32
+msgid "Double quote (U+0022)"
+msgstr "双引号（U+0022）"
+
+#: ../../language/lexical-conventions.md:32
+msgid "`\\'`"
+msgstr ""
+
+#: ../../language/lexical-conventions.md:32
+msgid "Single quote (U+0027)"
+msgstr "单引号（U+0027）"
+
+#: ../../language/lexical-conventions.md:32
+msgid "`\\/`"
+msgstr ""
+
+#: ../../language/lexical-conventions.md:32
+msgid "Forward slash (U+002F)"
+msgstr "正斜杠（U+002F）"
+
+#: ../../language/lexical-conventions.md:32
+msgid "`\\n`"
+msgstr ""
+
+#: ../../language/lexical-conventions.md:32
+msgid "Line feed (U+000A)"
+msgstr "换行符（U+000A）"
+
+#: ../../language/lexical-conventions.md:32
+msgid "`\\r`"
+msgstr ""
+
+#: ../../language/lexical-conventions.md:32
+msgid "Carriage return (U+000D)"
+msgstr "回车符（U+000D）"
+
+#: ../../language/lexical-conventions.md:32
+msgid "`\\t`"
+msgstr ""
+
+#: ../../language/lexical-conventions.md:32
+msgid "Horizontal tab (U+0009)"
+msgstr "水平制表符（U+0009）"
+
+#: ../../language/lexical-conventions.md:32
+msgid "`\\b`"
+msgstr ""
+
+#: ../../language/lexical-conventions.md:32
+msgid "Backspace (U+0008)"
+msgstr "退格符（U+0008）"
+
+#: ../../language/lexical-conventions.md:32
+msgid "`\\f`"
+msgstr ""
+
+#: ../../language/lexical-conventions.md:32
+msgid "Form feed (U+000C)"
+msgstr "换页符（U+000C）"
+
+#: ../../language/lexical-conventions.md:62
+msgid ""
+"A Unicode escape must denote a Unicode scalar value. A CR or LF before "
+"the closing quote reports an unterminated string literal."
+msgstr ""
+"Unicode 转义必须表示 Unicode 标量值。若在右引号之前遇到 CR 或 LF，则报告未"
+"终止的字符串字面量。"
+
+#: ../../language/lexical-conventions.md:65
+msgid "Interpolation"
+msgstr "插值"
+
+#: ../../language/lexical-conventions.md:71
+msgid ""
+"The expression must be nonempty and end at the matching `}`. Braces "
+"inside nested literals do not affect matching; nested interpolations are "
+"recognized recursively. CR, LF, `//` comments, attributes, and multiline "
+"string literals are not permitted."
+msgstr ""
+"表达式不能为空，并在匹配的 `}` 处结束。嵌套字面量中的大括号不影响配对；嵌"
+"套插值会被递归识别。不允许 CR、LF、`//` 注释、属性和多行字符串字面量。"
+
+#: ../../language/lexical-conventions.md:76
+msgid "Multiline String Literals"
+msgstr "多行字符串字面量"
+
+#: ../../language/lexical-conventions.md:95
+msgid ""
+"The prefixes are omitted from the result, and lines are joined with "
+"U+000A. A final empty prefixed line adds a trailing line feed. A `#|` "
+"line is literal; in a `$|` line, only `\\{` begins interpolation. "
+"Multiline strings are not permitted inside interpolation expressions."
+msgstr ""
+"前缀不计入结果，行之间以 U+000A 连接。最后一个带前缀的空行会添加末尾换行"
+"符。`#|` 行为原样文本；在 `$|` 行中，只有 `\\{` 开始插值。插值表达式内不允"
+"许多行字符串。"
+
+#: ../../language/lexical-conventions.md:100
+msgid "Bytes Literals"
+msgstr "字节序列字面量"
+
+#: ../../language/lexical-conventions.md:114
+msgid ""
+"A CR or LF before the closing quote reports an unterminated literal. Non-"
+"ASCII source characters contribute their UTF-8 encoding; `\\xHH` and "
+"`\\oDDD` each contribute one byte with a value from 0 to 255. "
+"Interpolation follows the string-literal rules. There is no multiline "
+"bytes-literal form."
+msgstr ""
+"若在右引号之前遇到 CR 或 LF，则报告未终止的字面量。非 ASCII 源字符写入其 "
+"UTF-8 编码；`\\xHH` 和 `\\oDDD` 各写入一个取值为 0 到 255 的字节。插值遵循"
+"字符串字面量规则。字节序列字面量没有多行形式。"
+
+#: ../../language/lexical-conventions.md:119
+msgid "Character Literals"
+msgstr "字符字面量"
+
+#: ../../language/lexical-conventions.md:131
+msgid ""
+"A character literal contains exactly one Unicode scalar value or escape "
+"sequence."
+msgstr "字符字面量恰好包含一个 Unicode 标量值或转义序列。"
+
+#: ../../language/lexical-conventions.md:134
+msgid "Byte Literals"
+msgstr "字节字面量"
+
+#: ../../language/lexical-conventions.md:146
+msgid ""
+"An unescaped byte is ASCII. Unicode escapes are invalid in byte literals."
+msgstr "未转义的字节必须是 ASCII。字节字面量中不允许 Unicode 转义。"


### PR DESCRIPTION
- Add a custom Sphinx grammar directive with OCaml Manual–style notation, syntax highlighting, stable anchors, and clickable cross-references between productions.
- Add a work-in-progress Lexical Conventions page documenting string, multiline string, bytes, character, and byte literals.
- Add the corresponding Simplified Chinese translation.


@bobzhang 