### PR TITLE
fix: correct MoonBit syntax highlighting

### DIFF
--- a/next/_ext/lexer.py
+++ b/next/_ext/lexer.py
@@ -19,7 +19,7 @@ class MoonBitLexer(RegexLexer):
         'root': [
             (r"#.*$", token.Comment.Preproc),
             (r"//.*$", token.Comment.Single),
-            (r"b?\'.*\'", token.Literal),
+            (r"b?'(?:\\(?:[0\\tnrb\"']|x[0-9a-fA-F]{2}|u\{[0-9a-fA-F]+\}|u[0-9a-fA-F]{4})|[^\\'\n])+'", token.Literal),
             (r"#\|.*$", token.String),
             (r"(b)(\")", bygroups(token.String.Affix, token.String), "string.inline"),
             ("\"", token.String, "string.inline"),
@@ -45,7 +45,7 @@ class MoonBitLexer(RegexLexer):
             (words(('true', 'false'), suffix=r"\b"), token.Keyword.Constant),
             (words(('Eq', 'Compare', 'Hash', 'Show', 'Default', 'ToJson', 'FromJson'), suffix=r"\b"), token.Name.Builtin),
             (words(('Array', 'FixedArray', 'Int', 'Int64', 'UInt', 'UInt64', 'Option', 'Result', 'Byte', 'Bool', 'Unit', 'String', 'Float', 'Double'), suffix=r"\b"), token.Name.Builtin),
-            (words(('+', '-', '*', '/', '%', '|>', '>>', '<<', '&&', '||', '&', '|', '<', '>', '==')), token.Operator),
+            (r"\|>|>>|<<|&&|\|\||==|!=|<=|>=|[+\-*/%&|<>]", token.Operator),
             (words(('not', 'lsl', 'lsr', 'asr', 'op_add', 'op_sub', 'op_div', 'op_mul', 'op_mod', '...')), token.Operator.Word),
             # @namespace.
             (r"@[A-Za-z][A-Za-z0-9_/]*\.", token.Name.Namespace),

--- a/next/_ext/lexer.py
+++ b/next/_ext/lexer.py
@@ -19,7 +19,7 @@ class MoonBitLexer(RegexLexer):
         'root': [
             (r"#.*$", token.Comment.Preproc),
             (r"//.*$", token.Comment.Single),
-            (r"b?'(?:\\(?:[0\\tnrb\"']|x[0-9a-fA-F]{2}|u\{[0-9a-fA-F]+\}|u[0-9a-fA-F]{4})|[^\\'\n])+'", token.Literal),
+            (r"b?'(?:\\.|[^\\'\n])+'", token.Literal),
             (r"#\|.*$", token.String),
             (r"(b)(\")", bygroups(token.String.Affix, token.String), "string.inline"),
             ("\"", token.String, "string.inline"),
@@ -45,7 +45,7 @@ class MoonBitLexer(RegexLexer):
             (words(('true', 'false'), suffix=r"\b"), token.Keyword.Constant),
             (words(('Eq', 'Compare', 'Hash', 'Show', 'Default', 'ToJson', 'FromJson'), suffix=r"\b"), token.Name.Builtin),
             (words(('Array', 'FixedArray', 'Int', 'Int64', 'UInt', 'UInt64', 'Option', 'Result', 'Byte', 'Bool', 'Unit', 'String', 'Float', 'Double'), suffix=r"\b"), token.Name.Builtin),
-            (r"\|>|>>|<<|&&|\|\||==|!=|<=|>=|[+\-*/%&|<>]", token.Operator),
+            (words(('+', '-', '*', '/', '%', '|>', '>>', '<<', '&&', '||', '&', '|', '<', '>', '==', '!=', '<=', '>=')), token.Operator),
             (words(('not', 'lsl', 'lsr', 'asr', 'op_add', 'op_sub', 'op_div', 'op_mul', 'op_mod', '...')), token.Operator.Word),
             # @namespace.
             (r"@[A-Za-z][A-Za-z0-9_/]*\.", token.Name.Namespace),

--- a/next/conf.py
+++ b/next/conf.py
@@ -49,6 +49,9 @@ smartquotes_excludes = {
   'builders': ['man', 'text', 'markdown', 'latex'],
 }
 
+# Avoid guess-highlighting output blocks and other snippets without a language.
+highlight_language = 'none'
+
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 

--- a/next/example/gmachine/gmachine-1.md
+++ b/next/example/gmachine/gmachine-1.md
@@ -8,7 +8,7 @@ Higher-order functions such as `map` and `filter` often serve as many people's f
 
 To enhance code efficiency, some propose leveraging compiler optimizations based on recurring patterns within higher-order functions. For instance, by rewriting `map(f, map(g, list))` as：
 
-```
+```moonbit
 map(fn (x) { f(g(x)) }, list)
 ```
 

--- a/next/language/attributes.md
+++ b/next/language/attributes.md
@@ -24,7 +24,7 @@ expr ::= LIDENT | UIDENT | STRING | 'true' | 'false'
 
 Attributes have two categories: the built-in attributes and user-defined attributes. For example:
 
-```
+```moonbit
 #deprecated("message")
 #custom.attribute(key="value", flag=true)
 ```


### PR DESCRIPTION
## Why

Sphinx currently guesses a lexer for blocks that do not declare a language, which gives plain output misleading syntax highlighting. The MoonBit lexer also greedily consumes from the first character-literal quote to the last quote on the line, and it does not recognize `!=`, `<=`, and `>=` as complete operators.

This supersedes #1279 because its head branch is in an organization-owned fork that upstream maintainers cannot update. The original commit and author attribution from @ubugeeei are preserved.

## What changed

- Stop character literals at the first unescaped quote while accepting escaped characters.
- Add the three missing composite operators using the existing `words(...)` declaration.
- Disable guessed highlighting for language-unspecified blocks.
- Explicitly mark the two existing untagged MoonBit source snippets as `moonbit`.

## Why this is correct and minimal

The bounded literal expression cannot cross an unescaped quote or newline, while remaining independent of the compiler's evolving escape-sequence list. Keeping `words(...)` limits the operator change to three additions. The global Sphinx default fixes output, diagnostics, command examples, grammar, and diagrams; only the two actual MoonBit source snippets need explicit language tags.