### PR TITLE
docs: document proof attributes

### DIFF
--- a/next/language/attributes.md
+++ b/next/language/attributes.md
@@ -118,3 +118,15 @@ We prefer to use compile-time code generation, keeping the benefits of static ty
 ```{include} /language/attributes/export_name.md
 :heading-offset: 1
 ```
+
+```{include} /language/attributes/proof_pure.md
+:heading-offset: 1
+```
+
+```{include} /language/attributes/proof_external.md
+:heading-offset: 1
+```
+
+```{include} /language/attributes/proof_import.md
+:heading-offset: 1
+```

--- a/next/language/attributes/proof_external.md
+++ b/next/language/attributes/proof_external.md
@@ -1,0 +1,18 @@
+# Proof External Attribute
+
+The `#proof_external(module, symbol)` attribute tells verification lowering to
+represent an abstract MoonBit type with a type from a Why3 module.
+
+```{literalinclude} /sources/verification/src/proof_shim.mbt
+:language: moonbit
+:start-after: start proof external 1
+:end-before: end proof external 1
+```
+
+In this example, occurrences of `ProofSet[T]` in proof-oriented logic are
+lowered to the Why3 type `set.Fset.fset T`. The attribute does not implement the
+MoonBit type, provide runtime values, or connect the type to an FFI ABI.
+
+The module and symbol mapping is part of the trusted verification boundary. For
+the corresponding operation imports and proof example, see
+[Formal Verification](/language/verification.md#proof-specific-annotations).

--- a/next/language/attributes/proof_import.md
+++ b/next/language/attributes/proof_import.md
@@ -1,0 +1,20 @@
+# Proof Import Attribute
+
+The `#proof_import(module)` attribute maps a proof-only logic declaration in a
+`.mbtp` file to a symbol from a Why3 module. The declaration's string body names
+the Why3 symbol; it is not an executable MoonBit expression.
+
+```{literalinclude} /sources/verification/src/proof_shim.mbtp
+:language: moonbit
+:start-after: start proof import 1
+:end-before: end proof import 1
+```
+
+Here, `set.Fset` is the Why3 module path, while `"mem"`, `"empty"`, and `"add"`
+name symbols in that module. These declarations affect verification lowering
+only and do not provide runtime implementations or FFI bindings. The final
+lemma creates a proof obligation; the imported declarations themselves do not.
+
+The declared signatures and symbol mappings are part of the trusted
+verification boundary. For a complete example and usage guidance, see
+[Formal Verification](/language/verification.md#proof-specific-annotations).

--- a/next/language/attributes/proof_pure.md
+++ b/next/language/attributes/proof_pure.md
@@ -1,0 +1,17 @@
+# Proof Pure Attribute
+
+The `#proof_pure` attribute makes a side-effect-free function available to both
+executable code and proof-oriented logic.
+
+```{literalinclude} /sources/verification/src/top.mbt
+:language: moonbit
+:start-after: start proof pure 1
+:end-before: end proof pure 1
+```
+
+It currently supports regular top-level functions and ordinary methods.
+Verification contracts, direct recursion, and mutual recursion are not yet
+supported on `#proof_pure` definitions.
+
+For its role in specifications and a complete example, see
+[Formal Verification](/language/verification.md#proof-specific-annotations).

--- a/next/language/verification.md
+++ b/next/language/verification.md
@@ -56,8 +56,9 @@ This example already shows the main structure of verified MoonBit code:
 - `proof_reasoning` records the proof idea in structured prose
 
 The rest of this page explains these pieces in more detail and introduces
-additional features such as `#proof_pure`, `proof_decrease`,
-`proof_axiomatized`, model-based verification, and the trusted surface.
+additional features such as `#proof_pure`, `#proof_external`, `#proof_import`,
+`proof_decrease`, `proof_axiomatized`, model-based verification, and the
+trusted surface.
 
 ## Setup
 
@@ -215,8 +216,50 @@ proof-facing computations that should behave like mathematical functions.
 
 At the moment, `#proof_pure` helpers are best treated as pure specification
 helpers rather than fully contracted verified functions. In particular, support
-for attaching ordinary verification contracts directly to `#proof_pure`
-definitions is still limited.
+is currently limited to regular top-level functions and ordinary methods.
+Verification contracts, direct recursion, and mutual recursion are not yet
+supported on `#proof_pure` definitions.
+
+### External Theories: `#proof_external` and `#proof_import`
+
+Proof-oriented libraries sometimes expose a MoonBit type whose logical model is
+provided by an existing Why3 theory. Two attributes form this bridge:
+
+- `#proof_external(module, symbol)` tells proof lowering to represent an
+  abstract MoonBit type with a type from a Why3 module.
+- `#proof_import(module)` declares a proof-only stub for an operation from a
+  Why3 module.
+
+For example, an opaque carrier can be represented by Why3's `set.Fset.fset` type
+during verification:
+
+```{literalinclude} /sources/verification/src/proof_shim.mbt
+:language: moonbit
+:start-after: start proof external 1
+:end-before: end proof external 1
+```
+
+The proof side can then declare stubs for Why3 operations and prove a property
+using the imported finite-set theory. Stub parameter order must match the Why3
+symbol:
+
+```{literalinclude} /sources/verification/src/proof_shim.mbtp
+:language: moonbit
+:start-after: start proof import 1
+:end-before: end proof import 1
+```
+
+Here, `set.Fset` is a Why3 module path, and the string body `"mem"` names a
+symbol in that module. A string body is special proof-stub syntax accepted in a
+`.mbtp` file; it is not an executable MoonBit expression and is unrelated to
+MoonBit FFI. The final lemma is an actual proof obligation discharged from the
+imported Why3 theory; none of these declarations can be called by runtime
+MoonBit code.
+
+Both attributes affect verification lowering only. `#proof_external` does not
+implement the MoonBit type or connect it to a runtime ABI, and `#proof_import`
+does not provide an executable function body. The declared signatures and their
+mapping to Why3 symbols are a trusted integration boundary.
 
 ### `proof_decrease`
 
@@ -421,6 +464,8 @@ The main trusted assumptions today are:
 
 - verification reasons about mathematical integers rather than machine integers
 - any item marked `proof_axiomatized` is assumed rather than proved
+- declarations using `#proof_external` or `#proof_import` correctly describe
+  the intended Why3 types and operations
 
 For integers, this means proof obligations are checked in an unbounded integer
 model. As a result:

--- a/next/locales/ja/LC_MESSAGES/language/attributes.po
+++ b/next/locales/ja/LC_MESSAGES/language/attributes.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MoonBit \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-03 17:22+0800\n"
+"POT-Creation-Date: 2026-08-06 11:39+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ja\n"
@@ -813,7 +813,8 @@ msgid ""
 "The compiler trusts this assertion during cycle-capability analysis and "
 "does not verify it."
 msgstr ""
-"`#unsafe_cycle_free` アトリビュートは、struct、enum、newtype の宣言に対する高度な最適化アサーションです。注釈を付けた型の値が参照サイクルに決して加わらないことをコンパイラに伝えます。コンパイラはサイクル可能性の解析でこのアサーションを信頼し、検証しません。"
+"`#unsafe_cycle_free` アトリビュートは、struct、enum、newtype "
+"の宣言に対する高度な最適化アサーションです。注釈を付けた型の値が参照サイクルに決して加わらないことをコンパイラに伝えます。コンパイラはサイクル可能性の解析でこのアサーションを信頼し、検証しません。"
 
 #: ../../language/attributes/unsafe_cycle_free.md:9
 msgid ""
@@ -828,8 +829,7 @@ msgid ""
 "Use this attribute only when the cycle-free invariant is guaranteed by "
 "the program. An incorrect assertion can cause reference cycles involving "
 "the type to be treated as impossible and therefore not reclaimed."
-msgstr ""
-"プログラムがサイクルフリー不変条件を保証できる場合にのみ、このアトリビュートを使ってください。誤ったアサーションにより、この型を含む参照サイクルが存在しないものとして扱われ、回収されなくなる可能性があります。"
+msgstr "プログラムがサイクルフリー不変条件を保証できる場合にのみ、このアトリビュートを使ってください。誤ったアサーションにより、この型を含む参照サイクルが存在しないものとして扱われ、回収されなくなる可能性があります。"
 
 #: ../../language/attributes/as_free_fn.md:2
 msgid "`as_free_fn` Attribute"
@@ -1053,3 +1053,120 @@ msgid ""
 "See [Export Functions](/language/ffi.md#export-functions) for backend-"
 "specific alternatives."
 msgstr ""
+
+#: ../../language/attributes/proof_pure.md:2
+msgid "Proof Pure Attribute"
+msgstr "Proof Pure アトリビュート"
+
+#: ../../language/attributes/proof_pure.md:4
+msgid ""
+"The `#proof_pure` attribute makes a side-effect-free function available "
+"to both executable code and proof-oriented logic."
+msgstr "`#proof_pure` アトリビュートは、副作用のない関数を実行可能コードと証明向けロジックの両方で利用できるようにします。"
+
+#: ../../language/attributes/proof_pure.md:7
+msgid ""
+"#proof_pure\n"
+"fn height(t : Tree) -> Int {\n"
+"  match t {\n"
+"    Empty => 0\n"
+"    Node(_, _, _, h) => h\n"
+"  }\n"
+"}\n"
+msgstr ""
+
+#: ../../language/attributes/proof_pure.md:13
+msgid ""
+"It currently supports regular top-level functions and ordinary methods. "
+"Verification contracts, direct recursion, and mutual recursion are not "
+"yet supported on `#proof_pure` definitions."
+msgstr "現在、通常のトップレベル関数と通常のメソッドをサポートしています。`#proof_pure` 定義では、検証契約、直接再帰、相互再帰はまだサポートされていません。"
+
+#: ../../language/attributes/proof_pure.md:17
+msgid ""
+"For its role in specifications and a complete example, see [Formal "
+"Verification](/language/verification.md#proof-specific-annotations)."
+msgstr "仕様における役割と完全な例については、[形式検証](/language/verification.md#proof-specific-annotations)を参照してください。"
+
+#: ../../language/attributes/proof_external.md:2
+msgid "Proof External Attribute"
+msgstr "Proof External アトリビュート"
+
+#: ../../language/attributes/proof_external.md:4
+msgid ""
+"The `#proof_external(module, symbol)` attribute tells verification "
+"lowering to represent an abstract MoonBit type with a type from a Why3 "
+"module."
+msgstr "`#proof_external(module, symbol)` アトリビュートは、検証時の変換で抽象 MoonBit 型を Why3 モジュール内の型として表現するよう指定します。"
+
+#: ../../language/attributes/proof_external.md:7
+msgid ""
+"///|\n"
+"#proof_external(\"set.Fset\", \"fset\")\n"
+"pub type ProofSet[T]\n"
+msgstr ""
+
+#: ../../language/attributes/proof_external.md:13
+msgid ""
+"In this example, occurrences of `ProofSet[T]` in proof-oriented logic are"
+" lowered to the Why3 type `set.Fset.fset T`. The attribute does not "
+"implement the MoonBit type, provide runtime values, or connect the type "
+"to an FFI ABI."
+msgstr "この例では、証明向けロジック内の `ProofSet[T]` は Why3 型 `set.Fset.fset T` に変換されます。このアトリビュートは MoonBit 型を実装せず、実行時の値も提供せず、その型を FFI ABI に接続することもありません。"
+
+#: ../../language/attributes/proof_external.md:17
+msgid ""
+"The module and symbol mapping is part of the trusted verification "
+"boundary. For the corresponding operation imports and proof example, see "
+"[Formal Verification](/language/verification.md#proof-specific-"
+"annotations)."
+msgstr "モジュールとシンボルの対応付けは、信頼される検証境界の一部です。対応する演算のインポートと証明例については、[形式検証](/language/verification.md#proof-specific-annotations)を参照してください。"
+
+#: ../../language/attributes/proof_import.md:2
+msgid "Proof Import Attribute"
+msgstr "Proof Import アトリビュート"
+
+#: ../../language/attributes/proof_import.md:4
+msgid ""
+"The `#proof_import(module)` attribute maps a proof-only logic declaration"
+" in a `.mbtp` file to a symbol from a Why3 module. The declaration's "
+"string body names the Why3 symbol; it is not an executable MoonBit "
+"expression."
+msgstr "`#proof_import(module)` アトリビュートは、`.mbtp` ファイル内の証明専用ロジック宣言を Why3 モジュールのシンボルに対応付けます。宣言の文字列本体は Why3 シンボルを指定するもので、実行可能な MoonBit 式ではありません。"
+
+#: ../../language/attributes/proof_import.md:8
+msgid ""
+"#proof_import(\"set.Fset\")\n"
+"fn proof_set_mem(x : Int, set : ProofSet[Int]) -> Bool = \"mem\"\n"
+"\n"
+"#proof_import(\"set.Fset\")\n"
+"fn proof_set_empty() -> ProofSet[Int] = \"empty\"\n"
+"\n"
+"#proof_import(\"set.Fset\")\n"
+"fn proof_set_add(x : Int, set : ProofSet[Int]) -> ProofSet[Int] = \"add\""
+"\n"
+"\n"
+"lemma proof_set_add_contains(x : Int) where {\n"
+"  proof_ensure: proof_set_mem(\n"
+"    x,\n"
+"    proof_set_add(x, proof_set_empty()),\n"
+"  ),\n"
+"} {}\n"
+msgstr ""
+
+#: ../../language/attributes/proof_import.md:14
+msgid ""
+"Here, `set.Fset` is the Why3 module path, while `\"mem\"`, `\"empty\"`, "
+"and `\"add\"` name symbols in that module. These declarations affect "
+"verification lowering only and do not provide runtime implementations or "
+"FFI bindings. The final lemma creates a proof obligation; the imported "
+"declarations themselves do not."
+msgstr "ここで、`set.Fset` は Why3 のモジュールパスであり、`\"mem\"`、`\"empty\"`、`\"add\"` はそのモジュール内のシンボルを指定します。これらの宣言は検証時の変換だけに影響し、実行時の実装や FFI バインディングは提供しません。最後の補題は証明義務を生成しますが、インポート宣言自体は生成しません。"
+
+#: ../../language/attributes/proof_import.md:19
+msgid ""
+"The declared signatures and symbol mappings are part of the trusted "
+"verification boundary. For a complete example and usage guidance, see "
+"[Formal Verification](/language/verification.md#proof-specific-"
+"annotations)."
+msgstr "宣言したシグネチャとシンボルの対応付けは、信頼される検証境界の一部です。完全な例と利用方法については、[形式検証](/language/verification.md#proof-specific-annotations)を参照してください。"

--- a/next/locales/ja/LC_MESSAGES/language/attributes/proof_external.po
+++ b/next/locales/ja/LC_MESSAGES/language/attributes/proof_external.po
@@ -1,0 +1,58 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026, International Digital Economy Academy
+# This file is distributed under the same license as the MoonBit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MoonBit \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-06 11:39+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../language/attributes/proof_external.md:1
+msgid "Proof External Attribute"
+msgstr "Proof External アトリビュート"
+
+#: ../../language/attributes/proof_external.md:3
+msgid ""
+"The `#proof_external(module, symbol)` attribute tells verification lowering "
+"to represent an abstract MoonBit type with a type from a Why3 module."
+msgstr ""
+"`#proof_external(module, symbol)` アトリビュートは、検証時の変換で抽象 "
+"MoonBit 型を Why3 モジュール内の型として表現するよう指定します。"
+
+#: ../../language/attributes/proof_external.md:6
+msgid ""
+"///|\n"
+"#proof_external(\"set.Fset\", \"fset\")\n"
+"pub type ProofSet[T]\n"
+msgstr ""
+
+#: ../../language/attributes/proof_external.md:12
+msgid ""
+"In this example, occurrences of `ProofSet[T]` in proof-oriented logic are "
+"lowered to the Why3 type `set.Fset.fset T`. The attribute does not implement "
+"the MoonBit type, provide runtime values, or connect the type to an FFI ABI."
+msgstr ""
+"この例では、証明向けロジック内の `ProofSet[T]` は Why3 型 `set.Fset.fset T` "
+"に変換されます。このアトリビュートは MoonBit 型を実装せず、実行時の値も提供せ"
+"ず、その型を FFI ABI に接続することもありません。"
+
+#: ../../language/attributes/proof_external.md:16
+msgid ""
+"The module and symbol mapping is part of the trusted verification boundary. "
+"For the corresponding operation imports and proof example, see [Formal "
+"Verification](/language/verification.md#proof-specific-annotations)."
+msgstr ""
+"モジュールとシンボルの対応付けは、信頼される検証境界の一部です。対応する演算"
+"のインポートと証明例については、[形式検証](/language/verification.md#proof-"
+"specific-annotations)を参照してください。"

--- a/next/locales/ja/LC_MESSAGES/language/attributes/proof_import.po
+++ b/next/locales/ja/LC_MESSAGES/language/attributes/proof_import.po
@@ -1,0 +1,75 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026, International Digital Economy Academy
+# This file is distributed under the same license as the MoonBit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MoonBit \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-06 11:39+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../language/attributes/proof_import.md:1
+msgid "Proof Import Attribute"
+msgstr "Proof Import アトリビュート"
+
+#: ../../language/attributes/proof_import.md:3
+msgid ""
+"The `#proof_import(module)` attribute maps a proof-only logic declaration in "
+"a `.mbtp` file to a symbol from a Why3 module. The declaration's string body "
+"names the Why3 symbol; it is not an executable MoonBit expression."
+msgstr ""
+"`#proof_import(module)` アトリビュートは、`.mbtp` ファイル内の証明専用ロジッ"
+"ク宣言を Why3 モジュールのシンボルに対応付けます。宣言の文字列本体は Why3 シ"
+"ンボルを指定するもので、実行可能な MoonBit 式ではありません。"
+
+#: ../../language/attributes/proof_import.md:7
+msgid ""
+"#proof_import(\"set.Fset\")\n"
+"fn proof_set_mem(x : Int, set : ProofSet[Int]) -> Bool = \"mem\"\n"
+"\n"
+"#proof_import(\"set.Fset\")\n"
+"fn proof_set_empty() -> ProofSet[Int] = \"empty\"\n"
+"\n"
+"#proof_import(\"set.Fset\")\n"
+"fn proof_set_add(x : Int, set : ProofSet[Int]) -> ProofSet[Int] = \"add\"\n"
+"\n"
+"lemma proof_set_add_contains(x : Int) where {\n"
+"  proof_ensure: proof_set_mem(\n"
+"    x,\n"
+"    proof_set_add(x, proof_set_empty()),\n"
+"  ),\n"
+"} {}\n"
+msgstr ""
+
+#: ../../language/attributes/proof_import.md:13
+msgid ""
+"Here, `set.Fset` is the Why3 module path, while `\"mem\"`, `\"empty\"`, and "
+"`\"add\"` name symbols in that module. These declarations affect "
+"verification lowering only and do not provide runtime implementations or FFI "
+"bindings. The final lemma creates a proof obligation; the imported "
+"declarations themselves do not."
+msgstr ""
+"ここで、`set.Fset` は Why3 のモジュールパスであり、`\"mem\"`、`\"empty\"`、"
+"`\"add\"` はそのモジュール内のシンボルを指定します。これらの宣言は検証時の変"
+"換だけに影響し、実行時の実装や FFI バインディングは提供しません。最後の補題は"
+"証明義務を生成しますが、インポート宣言自体は生成しません。"
+
+#: ../../language/attributes/proof_import.md:18
+msgid ""
+"The declared signatures and symbol mappings are part of the trusted "
+"verification boundary. For a complete example and usage guidance, see "
+"[Formal Verification](/language/verification.md#proof-specific-annotations)."
+msgstr ""
+"宣言したシグネチャとシンボルの対応付けは、信頼される検証境界の一部です。完全"
+"な例と利用方法については、[形式検証](/language/verification.md#proof-"
+"specific-annotations)を参照してください。"

--- a/next/locales/ja/LC_MESSAGES/language/attributes/proof_pure.po
+++ b/next/locales/ja/LC_MESSAGES/language/attributes/proof_pure.po
@@ -1,0 +1,60 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026, International Digital Economy Academy
+# This file is distributed under the same license as the MoonBit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MoonBit \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-06 11:18+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../language/attributes/proof_pure.md:1
+msgid "Proof Pure Attribute"
+msgstr "Proof Pure アトリビュート"
+
+#: ../../language/attributes/proof_pure.md:3
+msgid ""
+"The `#proof_pure` attribute makes a side-effect-free function available to "
+"both executable code and proof-oriented logic."
+msgstr ""
+"`#proof_pure` アトリビュートは、副作用のない関数を実行可能コードと証明向けロ"
+"ジックの両方で利用できるようにします。"
+
+#: ../../language/attributes/proof_pure.md:6
+msgid ""
+"#proof_pure\n"
+"fn height(t : Tree) -> Int {\n"
+"  match t {\n"
+"    Empty => 0\n"
+"    Node(_, _, _, h) => h\n"
+"  }\n"
+"}\n"
+msgstr ""
+
+#: ../../language/attributes/proof_pure.md:12
+msgid ""
+"It currently supports regular top-level functions and ordinary methods. "
+"Verification contracts, direct recursion, and mutual recursion are not yet "
+"supported on `#proof_pure` definitions."
+msgstr ""
+"現在、通常のトップレベル関数と通常のメソッドをサポートしています。"
+"`#proof_pure` 定義では、検証契約、直接再帰、相互再帰はまだサポートされていま"
+"せん。"
+
+#: ../../language/attributes/proof_pure.md:16
+msgid ""
+"For its role in specifications and a complete example, see [Formal "
+"Verification](/language/verification.md#proof-specific-annotations)."
+msgstr ""
+"仕様における役割と完全な例については、[形式検証](/language/"
+"verification.md#proof-specific-annotations)を参照してください。"

--- a/next/locales/ja/LC_MESSAGES/language/verification.po
+++ b/next/locales/ja/LC_MESSAGES/language/verification.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MoonBit \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-10 17:25+0800\n"
+"POT-Creation-Date: 2026-08-06 11:39+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ja\n"
@@ -103,7 +103,7 @@ msgstr ""
 msgid "Then define the logic-side specification in `.mbtp`:"
 msgstr ""
 
-#: ../../language/verification.md:35 ../../language/verification.md:277
+#: ../../language/verification.md:35 ../../language/verification.md:320
 msgid ""
 "predicate in_bounds(xs : FixedArray[Int], i : Int) {\n"
 "  (0 <= i) && (i < xs.length())\n"
@@ -212,88 +212,89 @@ msgstr ""
 #: ../../language/verification.md:58
 msgid ""
 "The rest of this page explains these pieces in more detail and introduces"
-" additional features such as `#proof_pure`, `proof_decrease`, "
-"`proof_axiomatized`, model-based verification, and the trusted surface."
+" additional features such as `#proof_pure`, `#proof_external`, "
+"`#proof_import`, `proof_decrease`, `proof_axiomatized`, model-based "
+"verification, and the trusted surface."
 msgstr ""
 
-#: ../../language/verification.md:62
+#: ../../language/verification.md:63
 msgid "Setup"
 msgstr ""
 
-#: ../../language/verification.md:64
+#: ../../language/verification.md:65
 msgid "Environment Setup"
 msgstr ""
 
-#: ../../language/verification.md:66
+#: ../../language/verification.md:67
 msgid ""
 "`moon prove` relies on the external Why3 verification toolchain. MoonBit "
 "lowers proof-enabled packages to Why3, and Why3 then dispatches proof "
 "obligations to one or more external solvers."
 msgstr ""
 
-#: ../../language/verification.md:70
+#: ../../language/verification.md:71
 msgid "Why3"
 msgstr ""
 
-#: ../../language/verification.md:72
+#: ../../language/verification.md:73
 msgid "Why3 is required to run formal verification in MoonBit."
 msgstr ""
 
-#: ../../language/verification.md:74
+#: ../../language/verification.md:75
 msgid "It is recommended to install Why3 through `opam`."
 msgstr ""
 
-#: ../../language/verification.md:75
+#: ../../language/verification.md:76
 msgid "The recommended pinned version is `1.7.2`."
 msgstr ""
 
-#: ../../language/verification.md:77
+#: ../../language/verification.md:78
 msgid ""
 "Using `opam` makes it easier to keep Why3 aligned with the version "
 "expected by the current MoonBit proof pipeline."
 msgstr ""
 
-#: ../../language/verification.md:80
+#: ../../language/verification.md:81
 msgid "External Solvers"
 msgstr ""
 
-#: ../../language/verification.md:82
+#: ../../language/verification.md:83
 msgid "At least one external solver must also be installed."
 msgstr ""
 
-#: ../../language/verification.md:84
+#: ../../language/verification.md:85
 msgid "MoonBit currently supports:"
 msgstr ""
 
-#: ../../language/verification.md:86
+#: ../../language/verification.md:87
 msgid "`z3`"
 msgstr ""
 
-#: ../../language/verification.md:87
+#: ../../language/verification.md:88
 msgid "`cvc5`"
 msgstr ""
 
-#: ../../language/verification.md:88
+#: ../../language/verification.md:89
 msgid "`alt-ergo`"
 msgstr ""
 
-#: ../../language/verification.md:90
+#: ../../language/verification.md:91
 msgid ""
 "Installing more than one solver can improve prover coverage, but a "
 "working setup only requires one of them to be available."
 msgstr ""
 
-#: ../../language/verification.md:93
+#: ../../language/verification.md:94
 msgid "Enabling Proofs in a Package"
 msgstr ""
 
-#: ../../language/verification.md:95
+#: ../../language/verification.md:96
 msgid ""
 "Proof support is enabled per package in `moon.pkg`, as shown in the "
 "overview example above."
 msgstr ""
 
-#: ../../language/verification.md:98
+#: ../../language/verification.md:99
 msgid ""
 "Once enabled, the package can contain both ordinary MoonBit source files "
 "and proof-oriented `.mbtp` files. Proof enablement is package-local: if "
@@ -301,27 +302,27 @@ msgid ""
 "enable it."
 msgstr ""
 
-#: ../../language/verification.md:102
+#: ../../language/verification.md:103
 msgid "Structure of Verified Code"
 msgstr ""
 
-#: ../../language/verification.md:104
+#: ../../language/verification.md:105
 msgid "Source Layout"
 msgstr ""
 
-#: ../../language/verification.md:106
+#: ../../language/verification.md:107
 msgid "Verification-oriented packages usually split into two layers:"
 msgstr ""
 
-#: ../../language/verification.md:108
+#: ../../language/verification.md:109
 msgid "`.mbt`: executable code, contracts, loop invariants, and local proof steps"
 msgstr ""
 
-#: ../../language/verification.md:109
+#: ../../language/verification.md:110
 msgid "`.mbtp`: predicates, abstract models, invariants, and lemmas"
 msgstr ""
 
-#: ../../language/verification.md:111
+#: ../../language/verification.md:112
 msgid ""
 "That split keeps runtime code readable while making proof structure "
 "explicit. In the [binary search overview](#overview-example-binary-"
@@ -329,160 +330,160 @@ msgid ""
 "function lives in `.mbt`."
 msgstr ""
 
-#: ../../language/verification.md:115
+#: ../../language/verification.md:116
 msgid "Program Side and Logic Side"
 msgstr ""
 
-#: ../../language/verification.md:117
+#: ../../language/verification.md:118
 msgid ""
 "MoonBit verification has a clear distinction between the program side and"
 " the logic side."
 msgstr ""
 
-#: ../../language/verification.md:120
+#: ../../language/verification.md:121
 msgid "The program side is executable MoonBit code."
 msgstr ""
 
-#: ../../language/verification.md:121
+#: ../../language/verification.md:122
 msgid ""
 "The logic side is used for specifications and proofs, and may not "
 "correspond to runtime code at all."
 msgstr ""
 
-#: ../../language/verification.md:124
+#: ../../language/verification.md:125
 msgid ""
 "Definitions in `.mbt` files are on the program side. Definitions in "
 "`.mbtp` files are on the logic side."
 msgstr ""
 
-#: ../../language/verification.md:127
+#: ../../language/verification.md:128
 msgid ""
 "This distinction is important because program-side definitions and logic-"
 "side definitions are separated:"
 msgstr ""
 
-#: ../../language/verification.md:130
+#: ../../language/verification.md:131
 msgid ""
 "program-side definitions are executable and can be called by ordinary "
 "MoonBit code"
 msgstr ""
 
-#: ../../language/verification.md:132
+#: ../../language/verification.md:133
 msgid "logic-side definitions are used by specifications and proofs"
 msgstr ""
 
-#: ../../language/verification.md:133
+#: ../../language/verification.md:134
 msgid "logic-side definitions in `.mbtp` are not ordinary runtime functions"
 msgstr ""
 
-#: ../../language/verification.md:134
+#: ../../language/verification.md:135
 msgid ""
 "program-side code does not call logic-side definitions as part of "
 "execution"
 msgstr ""
 
-#: ../../language/verification.md:135
+#: ../../language/verification.md:136
 msgid ""
 "logic-side specifications do not in general call arbitrary program-side "
 "definitions"
 msgstr ""
 
-#: ../../language/verification.md:138
+#: ../../language/verification.md:139
 msgid "This separation is the reason verified packages often have both:"
 msgstr ""
 
-#: ../../language/verification.md:140
+#: ../../language/verification.md:141
 msgid "program-side helper functions used by execution"
 msgstr ""
 
-#: ../../language/verification.md:141
+#: ../../language/verification.md:142
 msgid "logic-side predicates or model functions used by contracts"
 msgstr ""
 
-#: ../../language/verification.md:143
+#: ../../language/verification.md:144
 msgid ""
 "When one definition needs to be visible from both sides, `#proof_pure` is"
 " the mechanism for doing that."
 msgstr ""
 
-#: ../../language/verification.md:146
+#: ../../language/verification.md:147
 msgid ""
 "Within a `.mbt` file, contracts and proof annotations are the places "
 "where logic-side reasoning appears inside program code. In particular:"
 msgstr ""
 
-#: ../../language/verification.md:149
+#: ../../language/verification.md:150
 msgid ""
 "`proof_require` and `proof_ensure` are logic-side specifications attached"
 " to program functions"
 msgstr ""
 
-#: ../../language/verification.md:151
+#: ../../language/verification.md:152
 msgid "`proof_assert` states a logical fact that must be proved at that point"
 msgstr ""
 
-#: ../../language/verification.md:152
+#: ../../language/verification.md:153
 msgid ""
 "loop annotations such as `proof_invariant`, `proof_yield`, and "
 "`proof_reasoning` are logic-side statements about executable loops"
 msgstr ""
 
-#: ../../language/verification.md:155
+#: ../../language/verification.md:156
 msgid "Writing Specifications and Proofs"
 msgstr ""
 
-#: ../../language/verification.md:157
+#: ../../language/verification.md:158
 msgid "Contracts in `.mbt`"
 msgstr ""
 
-#: ../../language/verification.md:159
+#: ../../language/verification.md:160
 msgid ""
 "MoonBit uses `where { ... }` clauses for function contracts. In the "
 "binary search overview, the function contract appears directly on the "
 "program-side definition:"
 msgstr ""
 
-#: ../../language/verification.md:163
+#: ../../language/verification.md:164
 msgid "`proof_require` states a precondition."
 msgstr ""
 
-#: ../../language/verification.md:164
+#: ../../language/verification.md:165
 msgid "`proof_ensure` states a postcondition."
 msgstr ""
 
-#: ../../language/verification.md:165
+#: ../../language/verification.md:166
 msgid "`result` refers to the function result."
 msgstr ""
 
-#: ../../language/verification.md:167
+#: ../../language/verification.md:168
 msgid ""
 "Inside executable code, `proof_assert` can be used to record intermediate"
 " facts that help the prover connect the implementation to the "
 "specification."
 msgstr ""
 
-#: ../../language/verification.md:170
+#: ../../language/verification.md:171
 msgid ""
 "This is often the point where program-side implementation facts are "
 "connected to logic-side predicates and postconditions."
 msgstr ""
 
-#: ../../language/verification.md:173
+#: ../../language/verification.md:174
 msgid "Proof-Specific Annotations"
 msgstr ""
 
-#: ../../language/verification.md:175
+#: ../../language/verification.md:176
 msgid ""
 "Besides `proof_require`, `proof_ensure`, and `proof_assert`, MoonBit also"
 " has proof-specific annotations that control how definitions are treated "
 "by the proof pipeline."
 msgstr ""
 
-#: ../../language/verification.md:179
+#: ../../language/verification.md:180
 msgid "`#proof_pure`"
 msgstr ""
 
-#: ../../language/verification.md:181
+#: ../../language/verification.md:182
 msgid ""
 "`#proof_pure` marks a function as pure from the verifier's point of view."
 " This is useful for helper functions that compute logical quantities used"
@@ -490,7 +491,7 @@ msgid ""
 "program side."
 msgstr ""
 
-#: ../../language/verification.md:185
+#: ../../language/verification.md:186
 msgid ""
 "#proof_pure\n"
 "fn height(t : Tree) -> Int {\n"
@@ -501,18 +502,18 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/verification.md:191
+#: ../../language/verification.md:192
 msgid "The same helper can then be used in a specification:"
 msgstr ""
 
-#: ../../language/verification.md:193
+#: ../../language/verification.md:194
 msgid ""
 "predicate cached_height_ok(t : Tree, result : Int) {\n"
 "  result == height(t)\n"
 "}\n"
 msgstr ""
 
-#: ../../language/verification.md:199
+#: ../../language/verification.md:200
 msgid ""
 "The rationale for `#proof_pure` is that some computations naturally "
 "belong on both sides. A helper such as `height` on a tree can be useful "
@@ -520,30 +521,30 @@ msgid ""
 "same quantity."
 msgstr ""
 
-#: ../../language/verification.md:203
+#: ../../language/verification.md:204
 msgid "Without `#proof_pure`, this typically means:"
 msgstr ""
 
-#: ../../language/verification.md:205
+#: ../../language/verification.md:206
 msgid "writing one program-side definition for execution"
 msgstr ""
 
-#: ../../language/verification.md:206
+#: ../../language/verification.md:207
 msgid "writing a second logic-side definition for specifications"
 msgstr ""
 
-#: ../../language/verification.md:207
+#: ../../language/verification.md:208
 msgid "proving that the two definitions are equivalent before using them"
 msgstr ""
 
-#: ../../language/verification.md:209
+#: ../../language/verification.md:210
 msgid ""
 "`#proof_pure` avoids that duplication by allowing one side-effect-free "
 "MoonBit definition to be shared across program code and proof-oriented "
 "logic."
 msgstr ""
 
-#: ../../language/verification.md:212
+#: ../../language/verification.md:213
 msgid ""
 "In larger verified packages, `#proof_pure` is commonly used for helpers "
 "such as structural measures like height, ranking functions, summaries, "
@@ -551,23 +552,106 @@ msgid ""
 "functions."
 msgstr ""
 
-#: ../../language/verification.md:216
+#: ../../language/verification.md:217
 msgid ""
 "At the moment, `#proof_pure` helpers are best treated as pure "
 "specification helpers rather than fully contracted verified functions. In"
-" particular, support for attaching ordinary verification contracts "
-"directly to `#proof_pure` definitions is still limited."
-msgstr ""
-
-#: ../../language/verification.md:221
-msgid "`proof_decrease`"
+" particular, support is currently limited to regular top-level functions "
+"and ordinary methods. Verification contracts, direct recursion, and "
+"mutual recursion are not yet supported on `#proof_pure` definitions."
 msgstr ""
 
 #: ../../language/verification.md:223
-msgid "`proof_decrease` supplies a termination measure for recursive definitions."
+msgid "External Theories: `#proof_external` and `#proof_import`"
 msgstr ""
 
 #: ../../language/verification.md:225
+msgid ""
+"Proof-oriented libraries sometimes expose a MoonBit type whose logical "
+"model is provided by an existing Why3 theory. Two attributes form this "
+"bridge:"
+msgstr ""
+
+#: ../../language/verification.md:228
+msgid ""
+"`#proof_external(module, symbol)` tells proof lowering to represent an "
+"abstract MoonBit type with a type from a Why3 module."
+msgstr ""
+
+#: ../../language/verification.md:230
+msgid ""
+"`#proof_import(module)` declares a proof-only stub for an operation from "
+"a Why3 module."
+msgstr ""
+
+#: ../../language/verification.md:233
+msgid ""
+"For example, an opaque carrier can be represented by Why3's "
+"`set.Fset.fset` type during verification:"
+msgstr ""
+
+#: ../../language/verification.md:236
+msgid ""
+"///|\n"
+"#proof_external(\"set.Fset\", \"fset\")\n"
+"pub type ProofSet[T]\n"
+msgstr ""
+
+#: ../../language/verification.md:242
+msgid ""
+"The proof side can then declare stubs for Why3 operations and prove a "
+"property using the imported finite-set theory. Stub parameter order must "
+"match the Why3 symbol:"
+msgstr ""
+
+#: ../../language/verification.md:246
+msgid ""
+"#proof_import(\"set.Fset\")\n"
+"fn proof_set_mem(x : Int, set : ProofSet[Int]) -> Bool = \"mem\"\n"
+"\n"
+"#proof_import(\"set.Fset\")\n"
+"fn proof_set_empty() -> ProofSet[Int] = \"empty\"\n"
+"\n"
+"#proof_import(\"set.Fset\")\n"
+"fn proof_set_add(x : Int, set : ProofSet[Int]) -> ProofSet[Int] = \"add\""
+"\n"
+"\n"
+"lemma proof_set_add_contains(x : Int) where {\n"
+"  proof_ensure: proof_set_mem(\n"
+"    x,\n"
+"    proof_set_add(x, proof_set_empty()),\n"
+"  ),\n"
+"} {}\n"
+msgstr ""
+
+#: ../../language/verification.md:252
+msgid ""
+"Here, `set.Fset` is a Why3 module path, and the string body `\"mem\"` "
+"names a symbol in that module. A string body is special proof-stub syntax"
+" accepted in a `.mbtp` file; it is not an executable MoonBit expression "
+"and is unrelated to MoonBit FFI. The final lemma is an actual proof "
+"obligation discharged from the imported Why3 theory; none of these "
+"declarations can be called by runtime MoonBit code."
+msgstr ""
+
+#: ../../language/verification.md:259
+msgid ""
+"Both attributes affect verification lowering only. `#proof_external` does"
+" not implement the MoonBit type or connect it to a runtime ABI, and "
+"`#proof_import` does not provide an executable function body. The "
+"declared signatures and their mapping to Why3 symbols are a trusted "
+"integration boundary."
+msgstr ""
+
+#: ../../language/verification.md:264
+msgid "`proof_decrease`"
+msgstr ""
+
+#: ../../language/verification.md:266
+msgid "`proof_decrease` supplies a termination measure for recursive definitions."
+msgstr ""
+
+#: ../../language/verification.md:268
 msgid ""
 "pub fn countdown(n : Int) -> Int where {\n"
 "  proof_decrease: n,\n"
@@ -582,47 +666,47 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/verification.md:231
+#: ../../language/verification.md:274
 msgid ""
 "This annotation is especially important when structural recursion or a "
 "numeric measure is not obvious to the prover from the function body "
 "alone."
 msgstr ""
 
-#: ../../language/verification.md:234
+#: ../../language/verification.md:277
 msgid "`proof_axiomatized`"
 msgstr ""
 
-#: ../../language/verification.md:236
+#: ../../language/verification.md:279
 msgid ""
 "`proof_axiomatized` marks a contracted function or lemma as assumed "
 "rather than proved."
 msgstr ""
 
-#: ../../language/verification.md:239
+#: ../../language/verification.md:282
 msgid ""
 "This is useful when a definition should be available to later proofs, but"
 " its implementation or proof is intentionally left outside the current "
 "verification boundary."
 msgstr ""
 
-#: ../../language/verification.md:243
+#: ../../language/verification.md:286
 msgid "In practice, `proof_axiomatized` should be used sparingly:"
 msgstr ""
 
-#: ../../language/verification.md:245
+#: ../../language/verification.md:288
 msgid "on a function, it means the verifier assumes the stated contract"
 msgstr ""
 
-#: ../../language/verification.md:246
+#: ../../language/verification.md:289
 msgid "on a lemma, it means the verifier assumes the stated conclusion"
 msgstr ""
 
-#: ../../language/verification.md:248
+#: ../../language/verification.md:291
 msgid "For example:"
 msgstr ""
 
-#: ../../language/verification.md:250
+#: ../../language/verification.md:293
 msgid ""
 "pub fn assumed_nonnegative(x : Int) -> Int where {\n"
 "  proof_axiomatized: true,\n"
@@ -633,7 +717,7 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/verification.md:256
+#: ../../language/verification.md:299
 msgid ""
 "This kind of declaration can be useful as a temporary bridge while a "
 "proof is still being developed, or when the trusted boundary is "
@@ -642,70 +726,70 @@ msgid ""
 "function body."
 msgstr ""
 
-#: ../../language/verification.md:261
+#: ../../language/verification.md:304
 msgid ""
 "Because these assumptions are not discharged by `moon prove`, they become"
 " part of the trusted surface of the verified package."
 msgstr ""
 
-#: ../../language/verification.md:264
+#: ../../language/verification.md:307
 msgid "Predicates and Lemmas in `.mbtp`"
 msgstr ""
 
-#: ../../language/verification.md:266
+#: ../../language/verification.md:309
 msgid ""
 "Logical properties live in `.mbtp` files. In the [binary search overview"
 "](#overview-example-binary-search), the logic side defines:"
 msgstr ""
 
-#: ../../language/verification.md:269
+#: ../../language/verification.md:312
 msgid "`in_bounds` as a basic indexing predicate"
 msgstr ""
 
-#: ../../language/verification.md:270
+#: ../../language/verification.md:313
 msgid "`sorted` as the precondition on the input array"
 msgstr ""
 
-#: ../../language/verification.md:271
+#: ../../language/verification.md:314
 msgid ""
 "`binary_search_ok` as the postcondition relating the result to the array "
 "and the key"
 msgstr ""
 
-#: ../../language/verification.md:274
+#: ../../language/verification.md:317
 msgid ""
 "For example, predicates in `.mbtp` can define the logical vocabulary used"
 " by contracts:"
 msgstr ""
 
-#: ../../language/verification.md:283
+#: ../../language/verification.md:326
 msgid "For larger verified packages, `.mbtp` also holds:"
 msgstr ""
 
-#: ../../language/verification.md:285
+#: ../../language/verification.md:328
 msgid "abstract model functions such as `model(x)`"
 msgstr ""
 
-#: ../../language/verification.md:286
+#: ../../language/verification.md:329
 msgid "representation invariants such as `bridge_inv(x)` or `sparse_array_inv(x)`"
 msgstr ""
 
-#: ../../language/verification.md:287
+#: ../../language/verification.md:330
 msgid "named postconditions such as `deposit_post(...)`"
 msgstr ""
 
-#: ../../language/verification.md:288
+#: ../../language/verification.md:331
 msgid "reusable lemmas"
 msgstr ""
 
-#: ../../language/verification.md:290
+#: ../../language/verification.md:333
 msgid ""
 "Lemmas are proof-only declarations that capture reusable facts. Small "
 "lemmas may have an empty body when the prover can discharge them "
 "directly, while larger lemmas can use recursive proof structure:"
 msgstr ""
 
-#: ../../language/verification.md:294
+#: ../../language/verification.md:337
 msgid ""
 "lemma height_nonneg_lemma(t : Tree) where {\n"
 "  proof_decrease: t,\n"
@@ -722,107 +806,107 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/verification.md:300
+#: ../../language/verification.md:343
 msgid ""
 "In this example, `avl_inv` is a representation invariant for an AVL tree,"
 " and the lemma proves `height(t)` is nonnegative by structural recursion "
 "on `t`."
 msgstr ""
 
-#: ../../language/verification.md:303
+#: ../../language/verification.md:346
 msgid "Lemma bodies vary with the amount of proof guidance the solver needs:"
 msgstr ""
 
-#: ../../language/verification.md:305
+#: ../../language/verification.md:348
 msgid ""
 "some lemmas have an empty body because the verifier can discharge them "
 "directly"
 msgstr ""
 
-#: ../../language/verification.md:306
+#: ../../language/verification.md:349
 msgid ""
 "some lemmas use a sequence of `proof_assert` steps to expose intermediate"
 " facts"
 msgstr ""
 
-#: ../../language/verification.md:307
+#: ../../language/verification.md:350
 msgid ""
 "recursive lemmas can also call other lemmas, including themselves on "
 "smaller inputs"
 msgstr ""
 
-#: ../../language/verification.md:309
+#: ../../language/verification.md:352
 msgid "Loop Invariants"
 msgstr ""
 
-#: ../../language/verification.md:311
+#: ../../language/verification.md:354
 msgid ""
 "Loops are verified with proof-specific clauses in the loop's `where { ..."
 " }` block. In the [binary search overview](#overview-example-binary-"
 "search), the loop invariants state that:"
 msgstr ""
 
-#: ../../language/verification.md:314
+#: ../../language/verification.md:357
 msgid "the current search window is always a valid slice `[i, j)`"
 msgstr ""
 
-#: ../../language/verification.md:315
+#: ../../language/verification.md:358
 msgid "every index before `i` contains a value `< key`"
 msgstr ""
 
-#: ../../language/verification.md:316
+#: ../../language/verification.md:359
 msgid "every index from `j` onward contains a value `> key`"
 msgstr ""
 
-#: ../../language/verification.md:318
+#: ../../language/verification.md:361
 msgid "The most common loop proof annotations are:"
 msgstr ""
 
-#: ../../language/verification.md:320
+#: ../../language/verification.md:363
 msgid "`proof_invariant`: facts that must hold at every iteration boundary"
 msgstr ""
 
-#: ../../language/verification.md:321
+#: ../../language/verification.md:364
 msgid "`proof_yield`: facts that must hold for values yielded by `break`"
 msgstr ""
 
-#: ../../language/verification.md:322
+#: ../../language/verification.md:365
 msgid "`proof_reasoning`: a proof-oriented explanation of why the loop is correct"
 msgstr ""
 
-#: ../../language/verification.md:324
+#: ../../language/verification.md:367
 msgid ""
 "In practice, good loop invariants describe the current search window, "
 "prefix, or processed region rather than the entire algorithm all at once."
 msgstr ""
 
-#: ../../language/verification.md:327
+#: ../../language/verification.md:370
 msgid "Model-Based Verification"
 msgstr ""
 
-#: ../../language/verification.md:329
+#: ../../language/verification.md:372
 msgid ""
 "For data structures and stateful systems, the most useful pattern is "
 "often:"
 msgstr ""
 
-#: ../../language/verification.md:331
+#: ../../language/verification.md:374
 msgid "define an abstract model,"
 msgstr ""
 
-#: ../../language/verification.md:332
+#: ../../language/verification.md:375
 msgid "define a representation invariant,"
 msgstr ""
 
-#: ../../language/verification.md:333
+#: ../../language/verification.md:376
 msgid "specify each operation against the abstract model."
 msgstr ""
 
-#: ../../language/verification.md:335
+#: ../../language/verification.md:378
 msgid "An AVL tree is a representative example of this style:"
 msgstr ""
 
-#: ../../language/verification.md:337
+#: ../../language/verification.md:380
 msgid ""
 "fn Tree::model(self : Tree) -> Fset[Int] {\n"
 "  match self {\n"
@@ -846,27 +930,27 @@ msgid ""
 "}\n"
 msgstr ""
 
-#: ../../language/verification.md:343
+#: ../../language/verification.md:386
 msgid "Here:"
 msgstr ""
 
-#: ../../language/verification.md:345
+#: ../../language/verification.md:388
 msgid "`model()` maps a concrete tree to its abstract finite-set view"
 msgstr ""
 
-#: ../../language/verification.md:346
+#: ../../language/verification.md:389
 msgid ""
 "the quantified conditions inline the ordering constraints over that "
 "abstract model"
 msgstr ""
 
-#: ../../language/verification.md:348
+#: ../../language/verification.md:391
 msgid ""
 "`avl_inv` ties together recursive well-formedness, search-tree ordering, "
 "and cached-height correctness"
 msgstr ""
 
-#: ../../language/verification.md:351
+#: ../../language/verification.md:394
 msgid ""
 "This style scales much better than writing large inline boolean formulas "
 "in each contract. Each operation can be specified in terms of the "
@@ -874,188 +958,194 @@ msgid ""
 "local facts until the named postcondition follows."
 msgstr ""
 
-#: ../../language/verification.md:356
+#: ../../language/verification.md:399
 msgid "Recommended Style"
 msgstr ""
 
-#: ../../language/verification.md:358
+#: ../../language/verification.md:401
 msgid "Keep executable logic in `.mbt` and proof logic in `.mbtp`."
 msgstr ""
 
-#: ../../language/verification.md:359
+#: ../../language/verification.md:402
 msgid ""
 "Treat the program side and the logic side as distinct layers with a "
 "narrow bridge between them."
 msgstr ""
 
-#: ../../language/verification.md:361
+#: ../../language/verification.md:404
 msgid "Prefer named predicates over large inline formulas."
 msgstr ""
 
-#: ../../language/verification.md:362
+#: ../../language/verification.md:405
 msgid ""
 "Use small, stable invariants and postconditions such as `*_inv` and "
 "`*_post`."
 msgstr ""
 
-#: ../../language/verification.md:363
+#: ../../language/verification.md:406
 msgid ""
 "Add `proof_assert` after important construction steps, branches, and loop"
 " updates when the prover needs help."
 msgstr ""
 
-#: ../../language/verification.md:365
+#: ../../language/verification.md:408
 msgid ""
 "Start with simple algorithmic proofs, then move to model-based "
 "verification for data structures and protocols."
 msgstr ""
 
-#: ../../language/verification.md:367
+#: ../../language/verification.md:410
 msgid ""
 "Be deliberate about recursive helpers: `#proof_pure` and `proof_decrease`"
 " often determine whether a proof remains maintainable."
 msgstr ""
 
-#: ../../language/verification.md:370
+#: ../../language/verification.md:413
 msgid "Running Verification"
 msgstr ""
 
-#: ../../language/verification.md:372
+#: ../../language/verification.md:415
 msgid "What `moon prove` Checks"
 msgstr ""
 
-#: ../../language/verification.md:374
+#: ../../language/verification.md:417
 msgid "Running `moon prove` asks the verifier to prove obligations such as:"
 msgstr ""
 
-#: ../../language/verification.md:376
+#: ../../language/verification.md:419
 msgid "function preconditions imply the function body is safe to execute"
 msgstr ""
 
-#: ../../language/verification.md:377
+#: ../../language/verification.md:420
 msgid "postconditions hold on every return path"
 msgstr ""
 
-#: ../../language/verification.md:378
+#: ../../language/verification.md:421
 msgid "`proof_assert` statements are valid"
 msgstr ""
 
-#: ../../language/verification.md:379
+#: ../../language/verification.md:422
 msgid "loop invariants hold initially and are preserved"
 msgstr ""
 
-#: ../../language/verification.md:380
+#: ../../language/verification.md:423
 msgid "loop termination measures decrease when the loop form supports them"
 msgstr ""
 
-#: ../../language/verification.md:381
+#: ../../language/verification.md:424
 msgid "bounds checks and similar safety properties required by the proof"
 msgstr ""
 
-#: ../../language/verification.md:383
+#: ../../language/verification.md:426
 msgid "Running the Verifier"
 msgstr ""
 
-#: ../../language/verification.md:385
+#: ../../language/verification.md:428
 msgid "From a module root, run:"
 msgstr ""
 
-#: ../../language/verification.md:387
+#: ../../language/verification.md:430
 msgid "moon prove\n"
 msgstr ""
 
-#: ../../language/verification.md:391
+#: ../../language/verification.md:434
 msgid "This tries to prove the proof-enabled packages in the current module."
 msgstr ""
 
-#: ../../language/verification.md:393
+#: ../../language/verification.md:436
 msgid "To prove a single package, pass its path:"
 msgstr ""
 
-#: ../../language/verification.md:395
+#: ../../language/verification.md:438
 msgid "moon prove path/to/package\n"
 msgstr ""
 
-#: ../../language/verification.md:399
+#: ../../language/verification.md:442
 msgid ""
 "In this targeted mode, MoonBit tries to prove only the selected package. "
 "Its dependencies are assumed rather than reproved as part of the same "
 "command."
 msgstr ""
 
-#: ../../language/verification.md:402
+#: ../../language/verification.md:445
 msgid ""
 "MoonBit lowers the proof-enabled package to Why3 and invokes the "
 "configured provers on the generated verification conditions."
 msgstr ""
 
-#: ../../language/verification.md:405
+#: ../../language/verification.md:448
 msgid ""
 "`moon check` and `moon prove` serve different purposes here. `moon check`"
 " validates the package as MoonBit code, while `moon prove` tries to "
 "discharge its proof obligations."
 msgstr ""
 
-#: ../../language/verification.md:409
+#: ../../language/verification.md:452
 msgid "Trust Model and Limitations"
 msgstr ""
 
-#: ../../language/verification.md:411
+#: ../../language/verification.md:454
 msgid "Trusted Assumptions"
 msgstr ""
 
-#: ../../language/verification.md:413
+#: ../../language/verification.md:456
 msgid ""
 "Like any verification system, MoonBit's proof story has a trusted "
 "surface: some facts are assumed by the frontend and backend rather than "
 "proved inside user code."
 msgstr ""
 
-#: ../../language/verification.md:417
+#: ../../language/verification.md:460
 msgid ""
 "This trusted surface also includes any user-written item marked "
 "`proof_axiomatized`."
 msgstr ""
 
-#: ../../language/verification.md:420
+#: ../../language/verification.md:463
 msgid "The main trusted assumptions today are:"
 msgstr ""
 
-#: ../../language/verification.md:422
+#: ../../language/verification.md:465
 msgid ""
 "verification reasons about mathematical integers rather than machine "
 "integers"
 msgstr ""
 
-#: ../../language/verification.md:423
+#: ../../language/verification.md:466
 msgid "any item marked `proof_axiomatized` is assumed rather than proved"
 msgstr ""
 
-#: ../../language/verification.md:425
+#: ../../language/verification.md:467
+msgid ""
+"declarations using `#proof_external` or `#proof_import` correctly "
+"describe the intended Why3 types and operations"
+msgstr ""
+
+#: ../../language/verification.md:470
 msgid ""
 "For integers, this means proof obligations are checked in an unbounded "
 "integer model. As a result:"
 msgstr ""
 
-#: ../../language/verification.md:428
+#: ../../language/verification.md:473
 msgid "arithmetic proofs do not currently model runtime overflow"
 msgstr ""
 
-#: ../../language/verification.md:429
+#: ../../language/verification.md:474
 msgid ""
 "a program can be correct in the proof model and still need explicit range"
 " discipline in execution"
 msgstr ""
 
-#: ../../language/verification.md:431
+#: ../../language/verification.md:476
 msgid "machine-integer verification is planned, but is not the current default"
 msgstr ""
 
-#: ../../language/verification.md:433
+#: ../../language/verification.md:478
 msgid "Current Status"
 msgstr ""
 
-#: ../../language/verification.md:435
+#: ../../language/verification.md:480
 msgid ""
 "Formal verification in MoonBit is still experimental. The surface syntax,"
 " prover integration, and proof ergonomics are actively evolving, so it is"
@@ -1063,41 +1153,41 @@ msgid ""
 " strong, machine-checked guarantees."
 msgstr ""
 
-#: ../../language/verification.md:440
+#: ../../language/verification.md:485
 msgid "Preferred Verification Style"
 msgstr ""
 
-#: ../../language/verification.md:442
+#: ../../language/verification.md:487
 msgid ""
 "MoonBit's current verifier works best with a functional proof style and "
 "model-based specifications."
 msgstr ""
 
-#: ../../language/verification.md:445
+#: ../../language/verification.md:490
 msgid ""
 "Imperative features such as local mutation and in-place `FixedArray` "
 "updates are supported, but their verified use is more limited:"
 msgstr ""
 
-#: ../../language/verification.md:448
+#: ../../language/verification.md:493
 msgid "mutable state is expected to remain local"
 msgstr ""
 
-#: ../../language/verification.md:449
+#: ../../language/verification.md:494
 msgid "escaping uses of `FixedArray` are currently not supported"
 msgstr ""
 
-#: ../../language/verification.md:450
+#: ../../language/verification.md:495
 msgid ""
 "when both formulations are available, functional-style programs are "
 "preferred"
 msgstr ""
 
-#: ../../language/verification.md:452
+#: ../../language/verification.md:497
 msgid "Further Reading"
 msgstr ""
 
-#: ../../language/verification.md:454
+#: ../../language/verification.md:499
 msgid ""
 "For additional verified programs and reusable proof-oriented libraries, "
 "see the [`moonbit-community/verified`](https://github.com/moonbit-"

--- a/next/locales/zh_CN/LC_MESSAGES/language/attributes.po
+++ b/next/locales/zh_CN/LC_MESSAGES/language/attributes.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MoonBit \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-03 17:22+0800\n"
+"POT-Creation-Date: 2026-08-06 11:39+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: zh_CN\n"
@@ -793,7 +793,8 @@ msgid ""
 "The compiler trusts this assertion during cycle-capability analysis and "
 "does not verify it."
 msgstr ""
-"`#unsafe_cycle_free` 属性是用于 struct、enum 或 newtype 声明的高级优化断言。它告诉编译器，该类型的值永远不会参与引用环。编译器会在分析类型是否可能成环时信任此断言，而不会验证它。"
+"`#unsafe_cycle_free` 属性是用于 struct、enum 或 newtype "
+"声明的高级优化断言。它告诉编译器，该类型的值永远不会参与引用环。编译器会在分析类型是否可能成环时信任此断言，而不会验证它。"
 
 #: ../../language/attributes/unsafe_cycle_free.md:9
 msgid ""
@@ -808,8 +809,7 @@ msgid ""
 "Use this attribute only when the cycle-free invariant is guaranteed by "
 "the program. An incorrect assertion can cause reference cycles involving "
 "the type to be treated as impossible and therefore not reclaimed."
-msgstr ""
-"仅当程序能够保证无环不变量时才应使用此属性。错误的断言会使涉及该类型的引用环被视为不可能存在，从而无法回收。"
+msgstr "仅当程序能够保证无环不变量时才应使用此属性。错误的断言会使涉及该类型的引用环被视为不可能存在，从而无法回收。"
 
 #: ../../language/attributes/as_free_fn.md:2
 msgid "`as_free_fn` Attribute"
@@ -1039,3 +1039,120 @@ msgid ""
 "See [Export Functions](/language/ffi.md#export-functions) for backend-"
 "specific alternatives."
 msgstr "有关各后端的替代方式，请参阅[导出函数](/language/ffi.md#export-functions)。"
+
+#: ../../language/attributes/proof_pure.md:2
+msgid "Proof Pure Attribute"
+msgstr "Proof Pure 属性"
+
+#: ../../language/attributes/proof_pure.md:4
+msgid ""
+"The `#proof_pure` attribute makes a side-effect-free function available "
+"to both executable code and proof-oriented logic."
+msgstr "`#proof_pure` 属性使无副作用的函数可同时用于可执行代码和面向证明的逻辑。"
+
+#: ../../language/attributes/proof_pure.md:7
+msgid ""
+"#proof_pure\n"
+"fn height(t : Tree) -> Int {\n"
+"  match t {\n"
+"    Empty => 0\n"
+"    Node(_, _, _, h) => h\n"
+"  }\n"
+"}\n"
+msgstr ""
+
+#: ../../language/attributes/proof_pure.md:13
+msgid ""
+"It currently supports regular top-level functions and ordinary methods. "
+"Verification contracts, direct recursion, and mutual recursion are not "
+"yet supported on `#proof_pure` definitions."
+msgstr "目前，它支持普通的顶层函数和常规方法。`#proof_pure` 定义暂不支持验证契约、直接递归和相互递归。"
+
+#: ../../language/attributes/proof_pure.md:17
+msgid ""
+"For its role in specifications and a complete example, see [Formal "
+"Verification](/language/verification.md#proof-specific-annotations)."
+msgstr "有关它在规约中的作用和完整示例，请参阅[形式化验证](/language/verification.md#proof-specific-annotations)。"
+
+#: ../../language/attributes/proof_external.md:2
+msgid "Proof External Attribute"
+msgstr "Proof External 属性"
+
+#: ../../language/attributes/proof_external.md:4
+msgid ""
+"The `#proof_external(module, symbol)` attribute tells verification "
+"lowering to represent an abstract MoonBit type with a type from a Why3 "
+"module."
+msgstr "`#proof_external(module, symbol)` 属性指示验证降级过程使用 Why3 模块中的类型表示一个抽象 MoonBit 类型。"
+
+#: ../../language/attributes/proof_external.md:7
+msgid ""
+"///|\n"
+"#proof_external(\"set.Fset\", \"fset\")\n"
+"pub type ProofSet[T]\n"
+msgstr ""
+
+#: ../../language/attributes/proof_external.md:13
+msgid ""
+"In this example, occurrences of `ProofSet[T]` in proof-oriented logic are"
+" lowered to the Why3 type `set.Fset.fset T`. The attribute does not "
+"implement the MoonBit type, provide runtime values, or connect the type "
+"to an FFI ABI."
+msgstr "在本例中，面向证明的逻辑中的 `ProofSet[T]` 会降级为 Why3 类型 `set.Fset.fset T`。该属性不会实现这个 MoonBit 类型、提供运行时值，也不会将该类型连接到 FFI ABI。"
+
+#: ../../language/attributes/proof_external.md:17
+msgid ""
+"The module and symbol mapping is part of the trusted verification "
+"boundary. For the corresponding operation imports and proof example, see "
+"[Formal Verification](/language/verification.md#proof-specific-"
+"annotations)."
+msgstr "模块和符号映射是可信验证边界的一部分。有关对应的操作导入和证明示例，请参阅[形式化验证](/language/verification.md#proof-specific-annotations)。"
+
+#: ../../language/attributes/proof_import.md:2
+msgid "Proof Import Attribute"
+msgstr "Proof Import 属性"
+
+#: ../../language/attributes/proof_import.md:4
+msgid ""
+"The `#proof_import(module)` attribute maps a proof-only logic declaration"
+" in a `.mbtp` file to a symbol from a Why3 module. The declaration's "
+"string body names the Why3 symbol; it is not an executable MoonBit "
+"expression."
+msgstr "`#proof_import(module)` 属性将 `.mbtp` 文件中仅用于证明的逻辑声明映射到 Why3 模块中的符号。声明的字符串函数体指定 Why3 符号；它不是可执行的 MoonBit 表达式。"
+
+#: ../../language/attributes/proof_import.md:8
+msgid ""
+"#proof_import(\"set.Fset\")\n"
+"fn proof_set_mem(x : Int, set : ProofSet[Int]) -> Bool = \"mem\"\n"
+"\n"
+"#proof_import(\"set.Fset\")\n"
+"fn proof_set_empty() -> ProofSet[Int] = \"empty\"\n"
+"\n"
+"#proof_import(\"set.Fset\")\n"
+"fn proof_set_add(x : Int, set : ProofSet[Int]) -> ProofSet[Int] = \"add\""
+"\n"
+"\n"
+"lemma proof_set_add_contains(x : Int) where {\n"
+"  proof_ensure: proof_set_mem(\n"
+"    x,\n"
+"    proof_set_add(x, proof_set_empty()),\n"
+"  ),\n"
+"} {}\n"
+msgstr ""
+
+#: ../../language/attributes/proof_import.md:14
+msgid ""
+"Here, `set.Fset` is the Why3 module path, while `\"mem\"`, `\"empty\"`, "
+"and `\"add\"` name symbols in that module. These declarations affect "
+"verification lowering only and do not provide runtime implementations or "
+"FFI bindings. The final lemma creates a proof obligation; the imported "
+"declarations themselves do not."
+msgstr "这里，`set.Fset` 是 Why3 模块路径，而 `\"mem\"`、`\"empty\"` 和 `\"add\"` 指定该模块中的符号。这些声明只影响验证降级过程，并不提供运行时实现或 FFI 绑定。最后的引理会产生证明义务；导入声明本身不会。"
+
+#: ../../language/attributes/proof_import.md:19
+msgid ""
+"The declared signatures and symbol mappings are part of the trusted "
+"verification boundary. For a complete example and usage guidance, see "
+"[Formal Verification](/language/verification.md#proof-specific-"
+"annotations)."
+msgstr "声明的签名和符号映射是可信验证边界的一部分。有关完整示例和使用说明，请参阅[形式化验证](/language/verification.md#proof-specific-annotations)。"

--- a/next/locales/zh_CN/LC_MESSAGES/language/attributes/proof_external.po
+++ b/next/locales/zh_CN/LC_MESSAGES/language/attributes/proof_external.po
@@ -1,0 +1,57 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026, International Digital Economy Academy
+# This file is distributed under the same license as the MoonBit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MoonBit \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-06 11:39+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../language/attributes/proof_external.md:1
+msgid "Proof External Attribute"
+msgstr "Proof External 属性"
+
+#: ../../language/attributes/proof_external.md:3
+msgid ""
+"The `#proof_external(module, symbol)` attribute tells verification lowering "
+"to represent an abstract MoonBit type with a type from a Why3 module."
+msgstr ""
+"`#proof_external(module, symbol)` 属性指示验证降级过程使用 Why3 模块中的类型"
+"表示一个抽象 MoonBit 类型。"
+
+#: ../../language/attributes/proof_external.md:6
+msgid ""
+"///|\n"
+"#proof_external(\"set.Fset\", \"fset\")\n"
+"pub type ProofSet[T]\n"
+msgstr ""
+
+#: ../../language/attributes/proof_external.md:12
+msgid ""
+"In this example, occurrences of `ProofSet[T]` in proof-oriented logic are "
+"lowered to the Why3 type `set.Fset.fset T`. The attribute does not implement "
+"the MoonBit type, provide runtime values, or connect the type to an FFI ABI."
+msgstr ""
+"在本例中，面向证明的逻辑中的 `ProofSet[T]` 会降级为 Why3 类型 `set.Fset.fset "
+"T`。该属性不会实现这个 MoonBit 类型、提供运行时值，也不会将该类型连接到 FFI "
+"ABI。"
+
+#: ../../language/attributes/proof_external.md:16
+msgid ""
+"The module and symbol mapping is part of the trusted verification boundary. "
+"For the corresponding operation imports and proof example, see [Formal "
+"Verification](/language/verification.md#proof-specific-annotations)."
+msgstr ""
+"模块和符号映射是可信验证边界的一部分。有关对应的操作导入和证明示例，请参阅[形"
+"式化验证](/language/verification.md#proof-specific-annotations)。"

--- a/next/locales/zh_CN/LC_MESSAGES/language/attributes/proof_import.po
+++ b/next/locales/zh_CN/LC_MESSAGES/language/attributes/proof_import.po
@@ -1,0 +1,73 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026, International Digital Economy Academy
+# This file is distributed under the same license as the MoonBit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MoonBit \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-06 11:39+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../language/attributes/proof_import.md:1
+msgid "Proof Import Attribute"
+msgstr "Proof Import 属性"
+
+#: ../../language/attributes/proof_import.md:3
+msgid ""
+"The `#proof_import(module)` attribute maps a proof-only logic declaration in "
+"a `.mbtp` file to a symbol from a Why3 module. The declaration's string body "
+"names the Why3 symbol; it is not an executable MoonBit expression."
+msgstr ""
+"`#proof_import(module)` 属性将 `.mbtp` 文件中仅用于证明的逻辑声明映射到 Why3 "
+"模块中的符号。声明的字符串函数体指定 Why3 符号；它不是可执行的 MoonBit 表达"
+"式。"
+
+#: ../../language/attributes/proof_import.md:7
+msgid ""
+"#proof_import(\"set.Fset\")\n"
+"fn proof_set_mem(x : Int, set : ProofSet[Int]) -> Bool = \"mem\"\n"
+"\n"
+"#proof_import(\"set.Fset\")\n"
+"fn proof_set_empty() -> ProofSet[Int] = \"empty\"\n"
+"\n"
+"#proof_import(\"set.Fset\")\n"
+"fn proof_set_add(x : Int, set : ProofSet[Int]) -> ProofSet[Int] = \"add\"\n"
+"\n"
+"lemma proof_set_add_contains(x : Int) where {\n"
+"  proof_ensure: proof_set_mem(\n"
+"    x,\n"
+"    proof_set_add(x, proof_set_empty()),\n"
+"  ),\n"
+"} {}\n"
+msgstr ""
+
+#: ../../language/attributes/proof_import.md:13
+msgid ""
+"Here, `set.Fset` is the Why3 module path, while `\"mem\"`, `\"empty\"`, and "
+"`\"add\"` name symbols in that module. These declarations affect "
+"verification lowering only and do not provide runtime implementations or FFI "
+"bindings. The final lemma creates a proof obligation; the imported "
+"declarations themselves do not."
+msgstr ""
+"这里，`set.Fset` 是 Why3 模块路径，而 `\"mem\"`、`\"empty\"` 和 `\"add\"` 指"
+"定该模块中的符号。这些声明只影响验证降级过程，并不提供运行时实现或 FFI 绑定。"
+"最后的引理会产生证明义务；导入声明本身不会。"
+
+#: ../../language/attributes/proof_import.md:18
+msgid ""
+"The declared signatures and symbol mappings are part of the trusted "
+"verification boundary. For a complete example and usage guidance, see "
+"[Formal Verification](/language/verification.md#proof-specific-annotations)."
+msgstr ""
+"声明的签名和符号映射是可信验证边界的一部分。有关完整示例和使用说明，请参阅[形"
+"式化验证](/language/verification.md#proof-specific-annotations)。"

--- a/next/locales/zh_CN/LC_MESSAGES/language/attributes/proof_pure.po
+++ b/next/locales/zh_CN/LC_MESSAGES/language/attributes/proof_pure.po
@@ -1,0 +1,58 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026, International Digital Economy Academy
+# This file is distributed under the same license as the MoonBit package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MoonBit \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-06 11:18+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#: ../../language/attributes/proof_pure.md:1
+msgid "Proof Pure Attribute"
+msgstr "Proof Pure 属性"
+
+#: ../../language/attributes/proof_pure.md:3
+msgid ""
+"The `#proof_pure` attribute makes a side-effect-free function available to "
+"both executable code and proof-oriented logic."
+msgstr ""
+"`#proof_pure` 属性使无副作用的函数可同时用于可执行代码和面向证明的逻辑。"
+
+#: ../../language/attributes/proof_pure.md:6
+msgid ""
+"#proof_pure\n"
+"fn height(t : Tree) -> Int {\n"
+"  match t {\n"
+"    Empty => 0\n"
+"    Node(_, _, _, h) => h\n"
+"  }\n"
+"}\n"
+msgstr ""
+
+#: ../../language/attributes/proof_pure.md:12
+msgid ""
+"It currently supports regular top-level functions and ordinary methods. "
+"Verification contracts, direct recursion, and mutual recursion are not yet "
+"supported on `#proof_pure` definitions."
+msgstr ""
+"目前，它支持普通的顶层函数和常规方法。`#proof_pure` 定义暂不支持验证契约、直"
+"接递归和相互递归。"
+
+#: ../../language/attributes/proof_pure.md:16
+msgid ""
+"For its role in specifications and a complete example, see [Formal "
+"Verification](/language/verification.md#proof-specific-annotations)."
+msgstr ""
+"有关它在规约中的作用和完整示例，请参阅[形式化验证](/language/"
+"verification.md#proof-specific-annotations)。"

--- a/next/locales/zh_CN/LC_MESSAGES/language/verification.po
+++ b/next/locales/zh_CN/LC_MESSAGES/language/verification.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MoonBit \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-10 17:25+0800\n"
+"POT-Creation-Date: 2026-08-06 11:39+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: zh_CN\n"
@@ -108,7 +108,7 @@ msgstr ""
 msgid "Then define the logic-side specification in `.mbtp`:"
 msgstr "然后在 `.mbtp` 中定义逻辑侧规范："
 
-#: ../../language/verification.md:35 ../../language/verification.md:277
+#: ../../language/verification.md:35 ../../language/verification.md:320
 msgid ""
 "predicate in_bounds(xs : FixedArray[Int], i : Int) {\n"
 "  (0 <= i) && (i < xs.length())\n"
@@ -283,21 +283,22 @@ msgstr "`proof_reasoning` 用结构化文字记录证明思路"
 #: ../../language/verification.md:58
 msgid ""
 "The rest of this page explains these pieces in more detail and introduces"
-" additional features such as `#proof_pure`, `proof_decrease`, "
-"`proof_axiomatized`, model-based verification, and the trusted surface."
+" additional features such as `#proof_pure`, `#proof_external`, "
+"`#proof_import`, `proof_decrease`, `proof_axiomatized`, model-based "
+"verification, and the trusted surface."
 msgstr ""
 "本页后续部分会更详细地解释这些组成部分，并介绍 "
-"`#proof_pure`、`proof_decrease`、`proof_axiomatized`、基于模型的验证，以及可信边界等附加特性。"
+"`#proof_pure`、`#proof_external`、`#proof_import`、`proof_decrease`、`proof_axiomatized`、基于模型的验证，以及可信边界等附加特性。"
 
-#: ../../language/verification.md:62
+#: ../../language/verification.md:63
 msgid "Setup"
 msgstr "环境准备"
 
-#: ../../language/verification.md:64
+#: ../../language/verification.md:65
 msgid "Environment Setup"
 msgstr "环境配置"
 
-#: ../../language/verification.md:66
+#: ../../language/verification.md:67
 msgid ""
 "`moon prove` relies on the external Why3 verification toolchain. MoonBit "
 "lowers proof-enabled packages to Why3, and Why3 then dispatches proof "
@@ -306,69 +307,69 @@ msgstr ""
 "`moon prove` 依赖外部的 Why3 验证工具链。MoonBit 会将启用了证明的包转换为 Why3，随后由 Why3 "
 "将证明任务分派给一个或多个外部求解器。"
 
-#: ../../language/verification.md:70
+#: ../../language/verification.md:71
 msgid "Why3"
 msgstr "Why3"
 
-#: ../../language/verification.md:72
+#: ../../language/verification.md:73
 msgid "Why3 is required to run formal verification in MoonBit."
 msgstr "在 MoonBit 中运行形式化验证必须安装 Why3。"
 
-#: ../../language/verification.md:74
+#: ../../language/verification.md:75
 msgid "It is recommended to install Why3 through `opam`."
 msgstr "推荐通过 `opam` 安装 Why3。"
 
-#: ../../language/verification.md:75
+#: ../../language/verification.md:76
 msgid "The recommended pinned version is `1.7.2`."
 msgstr "推荐固定使用的版本为 `1.7.2`。"
 
-#: ../../language/verification.md:77
+#: ../../language/verification.md:78
 msgid ""
 "Using `opam` makes it easier to keep Why3 aligned with the version "
 "expected by the current MoonBit proof pipeline."
 msgstr "使用 `opam` 更容易让 Why3 与当前 MoonBit 证明流水线所期望的版本保持一致。"
 
-#: ../../language/verification.md:80
+#: ../../language/verification.md:81
 msgid "External Solvers"
 msgstr "外部求解器"
 
-#: ../../language/verification.md:82
+#: ../../language/verification.md:83
 msgid "At least one external solver must also be installed."
 msgstr "还必须至少安装一个外部求解器。"
 
-#: ../../language/verification.md:84
+#: ../../language/verification.md:85
 msgid "MoonBit currently supports:"
 msgstr "MoonBit 当前支持："
 
-#: ../../language/verification.md:86
+#: ../../language/verification.md:87
 msgid "`z3`"
 msgstr "`z3`"
 
-#: ../../language/verification.md:87
+#: ../../language/verification.md:88
 msgid "`cvc5`"
 msgstr "`cvc5`"
 
-#: ../../language/verification.md:88
+#: ../../language/verification.md:89
 msgid "`alt-ergo`"
 msgstr "`alt-ergo`"
 
-#: ../../language/verification.md:90
+#: ../../language/verification.md:91
 msgid ""
 "Installing more than one solver can improve prover coverage, but a "
 "working setup only requires one of them to be available."
 msgstr "安装多个求解器有助于提高证明覆盖率，但一个可用的环境只需要其中任意一个即可。"
 
-#: ../../language/verification.md:93
+#: ../../language/verification.md:94
 msgid "Enabling Proofs in a Package"
 msgstr "在包中启用证明"
 
-#: ../../language/verification.md:95
+#: ../../language/verification.md:96
 msgid ""
 "Proof support is enabled per package in `moon.pkg`, as shown in the "
 "overview example above."
 msgstr "证明支持是按包在 `moon.pkg` 中启用的，如上面的概览示例所示。"
 
-#: ../../language/verification.md:98
+#: ../../language/verification.md:99
 msgid ""
 "Once enabled, the package can contain both ordinary MoonBit source files "
 "and proof-oriented `.mbtp` files. Proof enablement is package-local: if "
@@ -378,27 +379,27 @@ msgstr ""
 "启用后，该包既可以包含普通的 MoonBit 源文件，也可以包含面向证明的 `.mbtp` "
 "文件。如果一个模块中的多个包都包含证明，那么每个这样的包都必须分别启用它。"
 
-#: ../../language/verification.md:102
+#: ../../language/verification.md:103
 msgid "Structure of Verified Code"
 msgstr "包含验证的代码的结构"
 
-#: ../../language/verification.md:104
+#: ../../language/verification.md:105
 msgid "Source Layout"
 msgstr "源码布局"
 
-#: ../../language/verification.md:106
+#: ../../language/verification.md:107
 msgid "Verification-oriented packages usually split into two layers:"
 msgstr "面向验证的包通常会分成两层："
 
-#: ../../language/verification.md:108
+#: ../../language/verification.md:109
 msgid "`.mbt`: executable code, contracts, loop invariants, and local proof steps"
 msgstr "`.mbt`：可执行代码、契约、循环不变量和局部证明步骤"
 
-#: ../../language/verification.md:109
+#: ../../language/verification.md:110
 msgid "`.mbtp`: predicates, abstract models, invariants, and lemmas"
 msgstr "`.mbtp`：谓词、抽象模型、不变量和引理"
 
-#: ../../language/verification.md:111
+#: ../../language/verification.md:112
 msgid ""
 "That split keeps runtime code readable while making proof structure "
 "explicit. In the [binary search overview](#overview-example-binary-"
@@ -408,99 +409,99 @@ msgstr ""
 "这种拆分方式在保持运行时代码可读性的同时，也让证明结构更加明确。在 [二分查找概览示例](#overview-example-binary-"
 "search) 中，谓词位于 `.mbtp` 中，而可执行的搜索函数位于 `.mbt` 中。"
 
-#: ../../language/verification.md:115
+#: ../../language/verification.md:116
 msgid "Program Side and Logic Side"
 msgstr "程序侧与逻辑侧"
 
-#: ../../language/verification.md:117
+#: ../../language/verification.md:118
 msgid ""
 "MoonBit verification has a clear distinction between the program side and"
 " the logic side."
 msgstr "MoonBit 的验证系统明确区分程序侧与逻辑侧。"
 
-#: ../../language/verification.md:120
+#: ../../language/verification.md:121
 msgid "The program side is executable MoonBit code."
 msgstr "程序侧是可执行的 MoonBit 代码。"
 
-#: ../../language/verification.md:121
+#: ../../language/verification.md:122
 msgid ""
 "The logic side is used for specifications and proofs, and may not "
 "correspond to runtime code at all."
 msgstr "逻辑侧用于编写规范与证明，它可能根本不对应任何运行时代码。"
 
-#: ../../language/verification.md:124
+#: ../../language/verification.md:125
 msgid ""
 "Definitions in `.mbt` files are on the program side. Definitions in "
 "`.mbtp` files are on the logic side."
 msgstr "`.mbt` 文件中的定义属于程序侧，`.mbtp` 文件中的定义属于逻辑侧。"
 
-#: ../../language/verification.md:127
+#: ../../language/verification.md:128
 msgid ""
 "This distinction is important because program-side definitions and logic-"
 "side definitions are separated:"
 msgstr "这种区分很重要，因为程序侧定义与逻辑侧定义是分离的："
 
-#: ../../language/verification.md:130
+#: ../../language/verification.md:131
 msgid ""
 "program-side definitions are executable and can be called by ordinary "
 "MoonBit code"
 msgstr "程序侧定义是可执行的，可以被普通 MoonBit 代码调用"
 
-#: ../../language/verification.md:132
+#: ../../language/verification.md:133
 msgid "logic-side definitions are used by specifications and proofs"
 msgstr "逻辑侧定义用于规范与证明"
 
-#: ../../language/verification.md:133
+#: ../../language/verification.md:134
 msgid "logic-side definitions in `.mbtp` are not ordinary runtime functions"
 msgstr "`.mbtp` 中的逻辑侧定义不是普通的运行时函数"
 
-#: ../../language/verification.md:134
+#: ../../language/verification.md:135
 msgid ""
 "program-side code does not call logic-side definitions as part of "
 "execution"
 msgstr "程序侧代码在执行过程中不会调用逻辑侧定义"
 
-#: ../../language/verification.md:135
+#: ../../language/verification.md:136
 msgid ""
 "logic-side specifications do not in general call arbitrary program-side "
 "definitions"
 msgstr "逻辑侧规范通常也不会任意调用程序侧定义"
 
-#: ../../language/verification.md:138
+#: ../../language/verification.md:139
 msgid "This separation is the reason verified packages often have both:"
 msgstr "正因为有这种分离，带证明的包通常会同时包含："
 
-#: ../../language/verification.md:140
+#: ../../language/verification.md:141
 msgid "program-side helper functions used by execution"
 msgstr "供执行时使用的程序侧辅助函数"
 
-#: ../../language/verification.md:141
+#: ../../language/verification.md:142
 msgid "logic-side predicates or model functions used by contracts"
 msgstr "供契约使用的逻辑侧谓词或模型函数"
 
-#: ../../language/verification.md:143
+#: ../../language/verification.md:144
 msgid ""
 "When one definition needs to be visible from both sides, `#proof_pure` is"
 " the mechanism for doing that."
 msgstr "当某个定义需要同时在两侧可见时，就可以使用 `#proof_pure`。"
 
-#: ../../language/verification.md:146
+#: ../../language/verification.md:147
 msgid ""
 "Within a `.mbt` file, contracts and proof annotations are the places "
 "where logic-side reasoning appears inside program code. In particular:"
 msgstr "在 `.mbt` 文件中，契约和证明注解是逻辑侧推理嵌入程序代码的位置。具体来说："
 
-#: ../../language/verification.md:149
+#: ../../language/verification.md:150
 msgid ""
 "`proof_require` and `proof_ensure` are logic-side specifications attached"
 " to program functions"
 msgstr "`proof_require` 和 `proof_ensure` 是附加在程序函数上的逻辑侧规范"
 
-#: ../../language/verification.md:151
+#: ../../language/verification.md:152
 msgid "`proof_assert` states a logical fact that must be proved at that point"
 msgstr "`proof_assert` 声明一个必须在该位置被证明的逻辑事实"
 
-#: ../../language/verification.md:152
+#: ../../language/verification.md:153
 msgid ""
 "loop annotations such as `proof_invariant`, `proof_yield`, and "
 "`proof_reasoning` are logic-side statements about executable loops"
@@ -508,51 +509,51 @@ msgstr ""
 "诸如 `proof_invariant`、`proof_yield` 和 `proof_reasoning` "
 "之类的循环注解，都是关于可执行循环的逻辑侧陈述"
 
-#: ../../language/verification.md:155
+#: ../../language/verification.md:156
 msgid "Writing Specifications and Proofs"
 msgstr "编写规范与证明"
 
-#: ../../language/verification.md:157
+#: ../../language/verification.md:158
 msgid "Contracts in `.mbt`"
 msgstr "`.mbt` 中的契约"
 
-#: ../../language/verification.md:159
+#: ../../language/verification.md:160
 msgid ""
 "MoonBit uses `where { ... }` clauses for function contracts. In the "
 "binary search overview, the function contract appears directly on the "
 "program-side definition:"
 msgstr "MoonBit 使用 `where { ... }` 子句来编写函数契约。在二分查找概览示例中，函数契约直接写在程序侧定义上："
 
-#: ../../language/verification.md:163
+#: ../../language/verification.md:164
 msgid "`proof_require` states a precondition."
 msgstr "`proof_require` 声明前置条件。"
 
-#: ../../language/verification.md:164
+#: ../../language/verification.md:165
 msgid "`proof_ensure` states a postcondition."
 msgstr "`proof_ensure` 声明后置条件。"
 
-#: ../../language/verification.md:165
+#: ../../language/verification.md:166
 msgid "`result` refers to the function result."
 msgstr "`result` 指代函数结果。"
 
-#: ../../language/verification.md:167
+#: ../../language/verification.md:168
 msgid ""
 "Inside executable code, `proof_assert` can be used to record intermediate"
 " facts that help the prover connect the implementation to the "
 "specification."
 msgstr "在可执行代码内部，可以用 `proof_assert` 记录中间事实，帮助证明器把实现与规范关联起来。"
 
-#: ../../language/verification.md:170
+#: ../../language/verification.md:171
 msgid ""
 "This is often the point where program-side implementation facts are "
 "connected to logic-side predicates and postconditions."
 msgstr "这通常就是把程序侧实现事实连接到逻辑侧谓词和后置条件的地方。"
 
-#: ../../language/verification.md:173
+#: ../../language/verification.md:174
 msgid "Proof-Specific Annotations"
 msgstr "证明专用注解"
 
-#: ../../language/verification.md:175
+#: ../../language/verification.md:176
 msgid ""
 "Besides `proof_require`, `proof_ensure`, and `proof_assert`, MoonBit also"
 " has proof-specific annotations that control how definitions are treated "
@@ -561,11 +562,11 @@ msgstr ""
 "除了 `proof_require`、`proof_ensure` 和 `proof_assert` 之外，MoonBit "
 "还提供了一些证明专用注解，用于控制证明流水线如何处理这些定义。"
 
-#: ../../language/verification.md:179
+#: ../../language/verification.md:180
 msgid "`#proof_pure`"
 msgstr "`#proof_pure`"
 
-#: ../../language/verification.md:181
+#: ../../language/verification.md:182
 msgid ""
 "`#proof_pure` marks a function as pure from the verifier's point of view."
 " This is useful for helper functions that compute logical quantities used"
@@ -575,7 +576,7 @@ msgstr ""
 "`#proof_pure` "
 "从验证器的角度将一个函数标记为纯函数。这适用于那些计算逻辑量的辅助函数：它们会出现在谓词和后置条件中，同时又需要在程序侧可见。"
 
-#: ../../language/verification.md:185
+#: ../../language/verification.md:186
 msgid ""
 "#proof_pure\n"
 "fn height(t : Tree) -> Int {\n"
@@ -593,11 +594,11 @@ msgstr ""
 "  }\n"
 "}\n"
 
-#: ../../language/verification.md:191
+#: ../../language/verification.md:192
 msgid "The same helper can then be used in a specification:"
 msgstr "同一个辅助函数随后就可以在规范中使用："
 
-#: ../../language/verification.md:193
+#: ../../language/verification.md:194
 msgid ""
 "predicate cached_height_ok(t : Tree, result : Int) {\n"
 "  result == height(t)\n"
@@ -607,7 +608,7 @@ msgstr ""
 "  result == height(t)\n"
 "}\n"
 
-#: ../../language/verification.md:199
+#: ../../language/verification.md:200
 msgid ""
 "The rationale for `#proof_pure` is that some computations naturally "
 "belong on both sides. A helper such as `height` on a tree can be useful "
@@ -617,30 +618,30 @@ msgstr ""
 "`#proof_pure` 的动机在于，有些计算天然同时属于两侧。例如树的 `height` "
 "这样的辅助函数，在可执行代码中很有用，而规范也可能需要引用同一个量。"
 
-#: ../../language/verification.md:203
+#: ../../language/verification.md:204
 msgid "Without `#proof_pure`, this typically means:"
 msgstr "如果没有 `#proof_pure`，通常就意味着："
 
-#: ../../language/verification.md:205
+#: ../../language/verification.md:206
 msgid "writing one program-side definition for execution"
 msgstr "写一个供执行使用的程序侧定义"
 
-#: ../../language/verification.md:206
+#: ../../language/verification.md:207
 msgid "writing a second logic-side definition for specifications"
 msgstr "再写一个供规范使用的逻辑侧定义"
 
-#: ../../language/verification.md:207
+#: ../../language/verification.md:208
 msgid "proving that the two definitions are equivalent before using them"
 msgstr "在使用之前还要证明这两个定义是等价的"
 
-#: ../../language/verification.md:209
+#: ../../language/verification.md:210
 msgid ""
 "`#proof_pure` avoids that duplication by allowing one side-effect-free "
 "MoonBit definition to be shared across program code and proof-oriented "
 "logic."
 msgstr "`#proof_pure` 允许一个无副作用的 MoonBit 定义被程序代码和面向证明的逻辑共同使用，从而避免这种重复。"
 
-#: ../../language/verification.md:212
+#: ../../language/verification.md:213
 msgid ""
 "In larger verified packages, `#proof_pure` is commonly used for helpers "
 "such as structural measures like height, ranking functions, summaries, "
@@ -648,25 +649,108 @@ msgid ""
 "functions."
 msgstr "在更大的验证包中，`#proof_pure` 常用于诸如高度这类结构度量、排序函数、汇总函数，以及其他应当像数学函数一样工作的面向证明的计算。"
 
-#: ../../language/verification.md:216
+#: ../../language/verification.md:217
 msgid ""
 "At the moment, `#proof_pure` helpers are best treated as pure "
 "specification helpers rather than fully contracted verified functions. In"
-" particular, support for attaching ordinary verification contracts "
-"directly to `#proof_pure` definitions is still limited."
+" particular, support is currently limited to regular top-level functions "
+"and ordinary methods. Verification contracts, direct recursion, and "
+"mutual recursion are not yet supported on `#proof_pure` definitions."
 msgstr ""
-"目前，`#proof_pure` 辅助函数更适合视为纯规范辅助函数，而不是带完整契约的已验证函数。尤其是，直接给 `#proof_pure` "
-"定义附加普通验证契约的支持仍然有限。"
+"目前，`#proof_pure` 辅助函数更适合视为纯规范辅助函数，而不是带完整契约的已验证函数。当前仅支持普通顶层函数和普通方法；`#proof_pure` "
+"定义尚不支持验证契约、直接递归或相互递归。"
 
-#: ../../language/verification.md:221
+#: ../../language/verification.md:223
+msgid "External Theories: `#proof_external` and `#proof_import`"
+msgstr "外部理论：`#proof_external` 与 `#proof_import`"
+
+#: ../../language/verification.md:225
+msgid ""
+"Proof-oriented libraries sometimes expose a MoonBit type whose logical "
+"model is provided by an existing Why3 theory. Two attributes form this "
+"bridge:"
+msgstr "面向证明的库有时会暴露一个 MoonBit 类型，而其逻辑模型由现有的 Why3 理论提供。以下两个属性共同构成这座桥梁："
+
+#: ../../language/verification.md:228
+msgid ""
+"`#proof_external(module, symbol)` tells proof lowering to represent an "
+"abstract MoonBit type with a type from a Why3 module."
+msgstr "`#proof_external(module, symbol)` 指示证明降级过程使用 Why3 模块中的类型表示一个抽象 MoonBit 类型。"
+
+#: ../../language/verification.md:230
+msgid ""
+"`#proof_import(module)` declares a proof-only stub for an operation from "
+"a Why3 module."
+msgstr "`#proof_import(module)` 为 Why3 模块中的操作声明一个仅用于证明的 stub。"
+
+#: ../../language/verification.md:233
+msgid ""
+"For example, an opaque carrier can be represented by Why3's "
+"`set.Fset.fset` type during verification:"
+msgstr "例如，在验证过程中，可以使用 Why3 的 `set.Fset.fset` 类型表示一个不透明载体："
+
+#: ../../language/verification.md:236
+msgid ""
+"///|\n"
+"#proof_external(\"set.Fset\", \"fset\")\n"
+"pub type ProofSet[T]\n"
+msgstr ""
+
+#: ../../language/verification.md:242
+msgid ""
+"The proof side can then declare stubs for Why3 operations and prove a "
+"property using the imported finite-set theory. Stub parameter order must "
+"match the Why3 symbol:"
+msgstr "随后，证明侧可以为 Why3 操作声明 stub，并使用导入的有限集合理论证明性质。stub 的参数顺序必须与 Why3 符号一致："
+
+#: ../../language/verification.md:246
+msgid ""
+"#proof_import(\"set.Fset\")\n"
+"fn proof_set_mem(x : Int, set : ProofSet[Int]) -> Bool = \"mem\"\n"
+"\n"
+"#proof_import(\"set.Fset\")\n"
+"fn proof_set_empty() -> ProofSet[Int] = \"empty\"\n"
+"\n"
+"#proof_import(\"set.Fset\")\n"
+"fn proof_set_add(x : Int, set : ProofSet[Int]) -> ProofSet[Int] = \"add\""
+"\n"
+"\n"
+"lemma proof_set_add_contains(x : Int) where {\n"
+"  proof_ensure: proof_set_mem(\n"
+"    x,\n"
+"    proof_set_add(x, proof_set_empty()),\n"
+"  ),\n"
+"} {}\n"
+msgstr ""
+
+#: ../../language/verification.md:252
+msgid ""
+"Here, `set.Fset` is a Why3 module path, and the string body `\"mem\"` "
+"names a symbol in that module. A string body is special proof-stub syntax"
+" accepted in a `.mbtp` file; it is not an executable MoonBit expression "
+"and is unrelated to MoonBit FFI. The final lemma is an actual proof "
+"obligation discharged from the imported Why3 theory; none of these "
+"declarations can be called by runtime MoonBit code."
+msgstr "这里，`set.Fset` 是 Why3 模块路径，字符串函数体 `\"mem\"` 指定该模块中的符号。字符串函数体是 `.mbtp` 文件接受的特殊 proof-stub 语法；它不是可执行的 MoonBit 表达式，也与 MoonBit FFI 无关。最后的引理是一项真正的证明义务，由导入的 Why3 理论消解；这些声明都不能由运行时 MoonBit 代码调用。"
+
+#: ../../language/verification.md:259
+msgid ""
+"Both attributes affect verification lowering only. `#proof_external` does"
+" not implement the MoonBit type or connect it to a runtime ABI, and "
+"`#proof_import` does not provide an executable function body. The "
+"declared signatures and their mapping to Why3 symbols are a trusted "
+"integration boundary."
+msgstr "这两个属性都只影响验证降级过程。`#proof_external` 不会实现 MoonBit 类型，也不会将其连接到运行时 ABI；`#proof_import` 不会提供可执行函数体。所声明的签名及其到 Why3 符号的映射属于可信集成边界。"
+
+#: ../../language/verification.md:264
 msgid "`proof_decrease`"
 msgstr "`proof_decrease`"
 
-#: ../../language/verification.md:223
+#: ../../language/verification.md:266
 msgid "`proof_decrease` supplies a termination measure for recursive definitions."
 msgstr "`proof_decrease` 为递归定义提供终止度量。"
 
-#: ../../language/verification.md:225
+#: ../../language/verification.md:268
 msgid ""
 "pub fn countdown(n : Int) -> Int where {\n"
 "  proof_decrease: n,\n"
@@ -692,47 +776,47 @@ msgstr ""
 "  }\n"
 "}\n"
 
-#: ../../language/verification.md:231
+#: ../../language/verification.md:274
 msgid ""
 "This annotation is especially important when structural recursion or a "
 "numeric measure is not obvious to the prover from the function body "
 "alone."
 msgstr "当证明器无法仅从函数体中直接看出结构递归或数值度量时，这个注解尤其重要。"
 
-#: ../../language/verification.md:234
+#: ../../language/verification.md:277
 msgid "`proof_axiomatized`"
 msgstr "`proof_axiomatized`"
 
-#: ../../language/verification.md:236
+#: ../../language/verification.md:279
 msgid ""
 "`proof_axiomatized` marks a contracted function or lemma as assumed "
 "rather than proved."
 msgstr "`proof_axiomatized` 将一个带契约的函数或引理标记为“被假定成立”，而不是“被证明成立”。"
 
-#: ../../language/verification.md:239
+#: ../../language/verification.md:282
 msgid ""
 "This is useful when a definition should be available to later proofs, but"
 " its implementation or proof is intentionally left outside the current "
 "verification boundary."
 msgstr "当某个定义需要供后续证明使用，但其实现或证明被有意留在当前验证边界之外时，这会很有用。"
 
-#: ../../language/verification.md:243
+#: ../../language/verification.md:286
 msgid "In practice, `proof_axiomatized` should be used sparingly:"
 msgstr "在实践中，应当谨慎使用 `proof_axiomatized`："
 
-#: ../../language/verification.md:245
+#: ../../language/verification.md:288
 msgid "on a function, it means the verifier assumes the stated contract"
 msgstr "用于函数时，表示验证器会直接假定所声明的契约成立"
 
-#: ../../language/verification.md:246
+#: ../../language/verification.md:289
 msgid "on a lemma, it means the verifier assumes the stated conclusion"
 msgstr "用于引理时，表示验证器会直接假定所声明的结论成立"
 
-#: ../../language/verification.md:248
+#: ../../language/verification.md:291
 msgid "For example:"
 msgstr "例如："
 
-#: ../../language/verification.md:250
+#: ../../language/verification.md:293
 msgid ""
 "pub fn assumed_nonnegative(x : Int) -> Int where {\n"
 "  proof_axiomatized: true,\n"
@@ -750,7 +834,7 @@ msgstr ""
 "  x\n"
 "}\n"
 
-#: ../../language/verification.md:256
+#: ../../language/verification.md:299
 msgid ""
 "This kind of declaration can be useful as a temporary bridge while a "
 "proof is still being developed, or when the trusted boundary is "
@@ -761,17 +845,17 @@ msgstr ""
 "当证明仍在开发过程中时，这类声明可以作为临时桥梁；或者当可信边界是有意且明确设定时，也可以使用它。关键在于，`moon prove` "
 "会把该契约当作假设来使用，而不是从函数体出发对其进行证明。"
 
-#: ../../language/verification.md:261
+#: ../../language/verification.md:304
 msgid ""
 "Because these assumptions are not discharged by `moon prove`, they become"
 " part of the trusted surface of the verified package."
 msgstr "由于这些假设不会被 `moon prove` 消解，它们就会成为已验证包可信边界的一部分。"
 
-#: ../../language/verification.md:264
+#: ../../language/verification.md:307
 msgid "Predicates and Lemmas in `.mbtp`"
 msgstr "`.mbtp` 中的谓词与引理"
 
-#: ../../language/verification.md:266
+#: ../../language/verification.md:309
 msgid ""
 "Logical properties live in `.mbtp` files. In the [binary search overview"
 "](#overview-example-binary-search), the logic side defines:"
@@ -779,54 +863,54 @@ msgstr ""
 "逻辑性质定义在 `.mbtp` 文件中。在 [二分查找概览示例](#overview-example-binary-search) "
 "中，逻辑侧定义了："
 
-#: ../../language/verification.md:269
+#: ../../language/verification.md:312
 msgid "`in_bounds` as a basic indexing predicate"
 msgstr "把 `in_bounds` 作为基本索引谓词"
 
-#: ../../language/verification.md:270
+#: ../../language/verification.md:313
 msgid "`sorted` as the precondition on the input array"
 msgstr "把 `sorted` 作为输入数组的前置条件"
 
-#: ../../language/verification.md:271
+#: ../../language/verification.md:314
 msgid ""
 "`binary_search_ok` as the postcondition relating the result to the array "
 "and the key"
 msgstr "把 `binary_search_ok` 作为把结果与数组及键值关联起来的后置条件"
 
-#: ../../language/verification.md:274
+#: ../../language/verification.md:317
 msgid ""
 "For example, predicates in `.mbtp` can define the logical vocabulary used"
 " by contracts:"
 msgstr "例如，`.mbtp` 中的谓词可以定义契约所使用的逻辑词汇："
 
-#: ../../language/verification.md:283
+#: ../../language/verification.md:326
 msgid "For larger verified packages, `.mbtp` also holds:"
 msgstr "对于更大的验证包，`.mbtp` 还会包含："
 
-#: ../../language/verification.md:285
+#: ../../language/verification.md:328
 msgid "abstract model functions such as `model(x)`"
 msgstr "如 `model(x)` 这样的抽象模型函数"
 
-#: ../../language/verification.md:286
+#: ../../language/verification.md:329
 msgid "representation invariants such as `bridge_inv(x)` or `sparse_array_inv(x)`"
 msgstr "如 `bridge_inv(x)` 或 `sparse_array_inv(x)` 这样的表示不变量"
 
-#: ../../language/verification.md:287
+#: ../../language/verification.md:330
 msgid "named postconditions such as `deposit_post(...)`"
 msgstr "如 `deposit_post(...)` 这样的具名后置条件"
 
-#: ../../language/verification.md:288
+#: ../../language/verification.md:331
 msgid "reusable lemmas"
 msgstr "可复用的引理"
 
-#: ../../language/verification.md:290
+#: ../../language/verification.md:333
 msgid ""
 "Lemmas are proof-only declarations that capture reusable facts. Small "
 "lemmas may have an empty body when the prover can discharge them "
 "directly, while larger lemmas can use recursive proof structure:"
 msgstr "引理是仅用于证明的声明，用来表达可复用的事实。当证明器可以直接消解时，较小的引理可以拥有空函数体；而更大的引理则可以使用递归的证明结构："
 
-#: ../../language/verification.md:294
+#: ../../language/verification.md:337
 msgid ""
 "lemma height_nonneg_lemma(t : Tree) where {\n"
 "  proof_decrease: t,\n"
@@ -856,40 +940,40 @@ msgstr ""
 "  }\n"
 "}\n"
 
-#: ../../language/verification.md:300
+#: ../../language/verification.md:343
 msgid ""
 "In this example, `avl_inv` is a representation invariant for an AVL tree,"
 " and the lemma proves `height(t)` is nonnegative by structural recursion "
 "on `t`."
 msgstr "在这个例子中，`avl_inv` 是 AVL 树的表示不变量，而这个引理通过对 `t` 进行结构递归来证明 `height(t)` 非负。"
 
-#: ../../language/verification.md:303
+#: ../../language/verification.md:346
 msgid "Lemma bodies vary with the amount of proof guidance the solver needs:"
 msgstr "引理体会随着求解器所需的证明引导程度而有所不同："
 
-#: ../../language/verification.md:305
+#: ../../language/verification.md:348
 msgid ""
 "some lemmas have an empty body because the verifier can discharge them "
 "directly"
 msgstr "有些引理的函数体为空，因为验证器可以直接完成证明"
 
-#: ../../language/verification.md:306
+#: ../../language/verification.md:349
 msgid ""
 "some lemmas use a sequence of `proof_assert` steps to expose intermediate"
 " facts"
 msgstr "有些引理会使用一连串 `proof_assert` 步骤来显式给出中间事实"
 
-#: ../../language/verification.md:307
+#: ../../language/verification.md:350
 msgid ""
 "recursive lemmas can also call other lemmas, including themselves on "
 "smaller inputs"
 msgstr "递归引理还可以调用其他引理，包括在更小输入上递归调用自身"
 
-#: ../../language/verification.md:309
+#: ../../language/verification.md:352
 msgid "Loop Invariants"
 msgstr "循环不变量"
 
-#: ../../language/verification.md:311
+#: ../../language/verification.md:354
 msgid ""
 "Loops are verified with proof-specific clauses in the loop's `where { ..."
 " }` block. In the [binary search overview](#overview-example-binary-"
@@ -898,67 +982,67 @@ msgstr ""
 "循环通过循环的 `where { ... }` 块中的证明专用子句来验证。在 [二分查找概览示例](#overview-example-"
 "binary-search) 中，循环不变量说明了："
 
-#: ../../language/verification.md:314
+#: ../../language/verification.md:357
 msgid "the current search window is always a valid slice `[i, j)`"
 msgstr "当前搜索窗口始终是一个合法的区间 `[i, j)`"
 
-#: ../../language/verification.md:315
+#: ../../language/verification.md:358
 msgid "every index before `i` contains a value `< key`"
 msgstr "`i` 之前的每个索引都包含 `< key` 的值"
 
-#: ../../language/verification.md:316
+#: ../../language/verification.md:359
 msgid "every index from `j` onward contains a value `> key`"
 msgstr "从 `j` 开始的每个索引都包含 `> key` 的值"
 
-#: ../../language/verification.md:318
+#: ../../language/verification.md:361
 msgid "The most common loop proof annotations are:"
 msgstr "最常见的循环证明注解有："
 
-#: ../../language/verification.md:320
+#: ../../language/verification.md:363
 msgid "`proof_invariant`: facts that must hold at every iteration boundary"
 msgstr "`proof_invariant`：在每次迭代边界都必须成立的事实"
 
-#: ../../language/verification.md:321
+#: ../../language/verification.md:364
 msgid "`proof_yield`: facts that must hold for values yielded by `break`"
 msgstr "`proof_yield`：对由 `break` 产出的值必须成立的事实"
 
-#: ../../language/verification.md:322
+#: ../../language/verification.md:365
 msgid "`proof_reasoning`: a proof-oriented explanation of why the loop is correct"
 msgstr "`proof_reasoning`：解释循环为何正确的面向证明的说明"
 
-#: ../../language/verification.md:324
+#: ../../language/verification.md:367
 msgid ""
 "In practice, good loop invariants describe the current search window, "
 "prefix, or processed region rather than the entire algorithm all at once."
 msgstr "在实践中，好的循环不变量通常描述当前搜索窗口、前缀或已处理区域，而不是一次性描述整个算法。"
 
-#: ../../language/verification.md:327
+#: ../../language/verification.md:370
 msgid "Model-Based Verification"
 msgstr "基于模型的验证"
 
-#: ../../language/verification.md:329
+#: ../../language/verification.md:372
 msgid ""
 "For data structures and stateful systems, the most useful pattern is "
 "often:"
 msgstr "对于数据结构和有状态系统，最有用的模式通常是："
 
-#: ../../language/verification.md:331
+#: ../../language/verification.md:374
 msgid "define an abstract model,"
 msgstr "定义一个抽象模型，"
 
-#: ../../language/verification.md:332
+#: ../../language/verification.md:375
 msgid "define a representation invariant,"
 msgstr "定义一个表示不变量，"
 
-#: ../../language/verification.md:333
+#: ../../language/verification.md:376
 msgid "specify each operation against the abstract model."
 msgstr "针对该抽象模型来为每个操作编写规范。"
 
-#: ../../language/verification.md:335
+#: ../../language/verification.md:378
 msgid "An AVL tree is a representative example of this style:"
 msgstr "AVL 树就是这种风格的一个代表性例子："
 
-#: ../../language/verification.md:337
+#: ../../language/verification.md:380
 msgid ""
 "fn Tree::model(self : Tree) -> Fset[Int] {\n"
 "  match self {\n"
@@ -1002,27 +1086,27 @@ msgstr ""
 "  }\n"
 "}\n"
 
-#: ../../language/verification.md:343
+#: ../../language/verification.md:386
 msgid "Here:"
 msgstr "这里："
 
-#: ../../language/verification.md:345
+#: ../../language/verification.md:388
 msgid "`model()` maps a concrete tree to its abstract finite-set view"
 msgstr "`model()` 把具体的树映射为它的抽象有限集合视图"
 
-#: ../../language/verification.md:346
+#: ../../language/verification.md:389
 msgid ""
 "the quantified conditions inline the ordering constraints over that "
 "abstract model"
 msgstr "内联的量词条件描述了该抽象模型上的顺序约束"
 
-#: ../../language/verification.md:348
+#: ../../language/verification.md:391
 msgid ""
 "`avl_inv` ties together recursive well-formedness, search-tree ordering, "
 "and cached-height correctness"
 msgstr "`avl_inv` 将递归的良构性、搜索树顺序以及缓存高度的正确性绑定在一起"
 
-#: ../../language/verification.md:351
+#: ../../language/verification.md:394
 msgid ""
 "This style scales much better than writing large inline boolean formulas "
 "in each contract. Each operation can be specified in terms of the "
@@ -1030,122 +1114,122 @@ msgid ""
 "local facts until the named postcondition follows."
 msgstr "与在每个契约中直接写庞大的内联布尔公式相比，这种风格的可扩展性要好得多。每个操作都可以基于抽象模型和不变量来编写规范，而实现部分则通过证明局部事实，最终推出相应的具名后置条件。"
 
-#: ../../language/verification.md:356
+#: ../../language/verification.md:399
 msgid "Recommended Style"
 msgstr "推荐风格"
 
-#: ../../language/verification.md:358
+#: ../../language/verification.md:401
 msgid "Keep executable logic in `.mbt` and proof logic in `.mbtp`."
 msgstr "把可执行逻辑放在 `.mbt` 中，把证明逻辑放在 `.mbtp` 中。"
 
-#: ../../language/verification.md:359
+#: ../../language/verification.md:402
 msgid ""
 "Treat the program side and the logic side as distinct layers with a "
 "narrow bridge between them."
 msgstr "将程序侧和逻辑侧视为两个不同的层次，它们之间只通过一个狭窄的桥梁连接。"
 
-#: ../../language/verification.md:361
+#: ../../language/verification.md:404
 msgid "Prefer named predicates over large inline formulas."
 msgstr "优先使用具名谓词，而不是大型内联公式。"
 
-#: ../../language/verification.md:362
+#: ../../language/verification.md:405
 msgid ""
 "Use small, stable invariants and postconditions such as `*_inv` and "
 "`*_post`."
 msgstr "使用小而稳定的不变量和后置条件，例如 `*_inv` 与 `*_post`。"
 
-#: ../../language/verification.md:363
+#: ../../language/verification.md:406
 msgid ""
 "Add `proof_assert` after important construction steps, branches, and loop"
 " updates when the prover needs help."
 msgstr "当证明器需要帮助时，在重要的构造步骤、分支和循环更新之后加入 `proof_assert`。"
 
-#: ../../language/verification.md:365
+#: ../../language/verification.md:408
 msgid ""
 "Start with simple algorithmic proofs, then move to model-based "
 "verification for data structures and protocols."
 msgstr "从简单的算法证明开始，然后再过渡到针对数据结构和协议的基于模型的验证。"
 
-#: ../../language/verification.md:367
+#: ../../language/verification.md:410
 msgid ""
 "Be deliberate about recursive helpers: `#proof_pure` and `proof_decrease`"
 " often determine whether a proof remains maintainable."
 msgstr "谨慎设计递归辅助函数：`#proof_pure` 和 `proof_decrease` 往往决定了一个证明是否仍然易于维护。"
 
-#: ../../language/verification.md:370
+#: ../../language/verification.md:413
 msgid "Running Verification"
 msgstr "运行验证"
 
-#: ../../language/verification.md:372
+#: ../../language/verification.md:415
 msgid "What `moon prove` Checks"
 msgstr "`moon prove` 会检查什么"
 
-#: ../../language/verification.md:374
+#: ../../language/verification.md:417
 msgid "Running `moon prove` asks the verifier to prove obligations such as:"
 msgstr "运行 `moon prove` 会要求验证器证明如下几类义务："
 
-#: ../../language/verification.md:376
+#: ../../language/verification.md:419
 msgid "function preconditions imply the function body is safe to execute"
 msgstr "函数前置条件足以保证函数体可以安全执行"
 
-#: ../../language/verification.md:377
+#: ../../language/verification.md:420
 msgid "postconditions hold on every return path"
 msgstr "后置条件在每一条返回路径上都成立"
 
-#: ../../language/verification.md:378
+#: ../../language/verification.md:421
 msgid "`proof_assert` statements are valid"
 msgstr "`proof_assert` 语句是有效的"
 
-#: ../../language/verification.md:379
+#: ../../language/verification.md:422
 msgid "loop invariants hold initially and are preserved"
 msgstr "循环不变量初始成立，并且在循环过程中得以保持"
 
-#: ../../language/verification.md:380
+#: ../../language/verification.md:423
 msgid "loop termination measures decrease when the loop form supports them"
 msgstr "当循环形式支持时，循环的终止度量会递减"
 
-#: ../../language/verification.md:381
+#: ../../language/verification.md:424
 msgid "bounds checks and similar safety properties required by the proof"
 msgstr "证明所需的边界检查和类似的安全性质"
 
-#: ../../language/verification.md:383
+#: ../../language/verification.md:426
 msgid "Running the Verifier"
 msgstr "运行验证器"
 
-#: ../../language/verification.md:385
+#: ../../language/verification.md:428
 msgid "From a module root, run:"
 msgstr "在模块根目录下运行："
 
-#: ../../language/verification.md:387
+#: ../../language/verification.md:430
 msgid "moon prove\n"
 msgstr "moon prove\n"
 
-#: ../../language/verification.md:391
+#: ../../language/verification.md:434
 msgid "This tries to prove the proof-enabled packages in the current module."
 msgstr "这会尝试证明当前模块中所有启用了证明的包。"
 
-#: ../../language/verification.md:393
+#: ../../language/verification.md:436
 msgid "To prove a single package, pass its path:"
 msgstr "如果只想证明一个包，可以传入它的路径："
 
-#: ../../language/verification.md:395
+#: ../../language/verification.md:438
 msgid "moon prove path/to/package\n"
 msgstr "moon prove path/to/package\n"
 
-#: ../../language/verification.md:399
+#: ../../language/verification.md:442
 msgid ""
 "In this targeted mode, MoonBit tries to prove only the selected package. "
 "Its dependencies are assumed rather than reproved as part of the same "
 "command."
 msgstr "在这种定向模式下，MoonBit 只会尝试证明被选中的包；它的依赖会被当作假设，而不会作为同一条命令的一部分重新证明。"
 
-#: ../../language/verification.md:402
+#: ../../language/verification.md:445
 msgid ""
 "MoonBit lowers the proof-enabled package to Why3 and invokes the "
 "configured provers on the generated verification conditions."
 msgstr "MoonBit 会把启用了证明的包转换为 Why3，并调用已配置的证明器处理生成的验证条件。"
 
-#: ../../language/verification.md:405
+#: ../../language/verification.md:448
 msgid ""
 "`moon check` and `moon prove` serve different purposes here. `moon check`"
 " validates the package as MoonBit code, while `moon prove` tries to "
@@ -1154,66 +1238,72 @@ msgstr ""
 "`moon check` 和 `moon prove` 在这里承担不同的职责。`moon check` 负责把包作为 MoonBit "
 "代码进行校验，而 `moon prove` 则尝试消解它的证明义务。"
 
-#: ../../language/verification.md:409
+#: ../../language/verification.md:452
 msgid "Trust Model and Limitations"
 msgstr "可信模型与限制"
 
-#: ../../language/verification.md:411
+#: ../../language/verification.md:454
 msgid "Trusted Assumptions"
 msgstr "受信假设"
 
-#: ../../language/verification.md:413
+#: ../../language/verification.md:456
 msgid ""
 "Like any verification system, MoonBit's proof story has a trusted "
 "surface: some facts are assumed by the frontend and backend rather than "
 "proved inside user code."
 msgstr "和任何验证系统一样，MoonBit 的证明体系也有一个可信边界：某些事实由前端和后端直接假定，而不是在用户代码内部加以证明。"
 
-#: ../../language/verification.md:417
+#: ../../language/verification.md:460
 msgid ""
 "This trusted surface also includes any user-written item marked "
 "`proof_axiomatized`."
 msgstr "任何用户编写且标记为 `proof_axiomatized` 的项目，也属于这个可信边界。"
 
-#: ../../language/verification.md:420
+#: ../../language/verification.md:463
 msgid "The main trusted assumptions today are:"
 msgstr "当前主要的可信假设包括："
 
-#: ../../language/verification.md:422
+#: ../../language/verification.md:465
 msgid ""
 "verification reasons about mathematical integers rather than machine "
 "integers"
 msgstr "验证所推理的是数学整数，而不是机器整数"
 
-#: ../../language/verification.md:423
+#: ../../language/verification.md:466
 msgid "any item marked `proof_axiomatized` is assumed rather than proved"
 msgstr "任何标记为 `proof_axiomatized` 的项目都会被当作假设，而不是被证明"
 
-#: ../../language/verification.md:425
+#: ../../language/verification.md:467
+msgid ""
+"declarations using `#proof_external` or `#proof_import` correctly "
+"describe the intended Why3 types and operations"
+msgstr "使用 `#proof_external` 或 `#proof_import` 的声明正确描述了预期的 Why3 类型和操作"
+
+#: ../../language/verification.md:470
 msgid ""
 "For integers, this means proof obligations are checked in an unbounded "
 "integer model. As a result:"
 msgstr "对整数来说，这意味着证明义务是在一个无界整数模型下进行检查的。因此："
 
-#: ../../language/verification.md:428
+#: ../../language/verification.md:473
 msgid "arithmetic proofs do not currently model runtime overflow"
 msgstr "算术证明目前不会建模运行时溢出"
 
-#: ../../language/verification.md:429
+#: ../../language/verification.md:474
 msgid ""
 "a program can be correct in the proof model and still need explicit range"
 " discipline in execution"
 msgstr "一个程序在证明模型中可能是正确的，但在实际执行时仍然需要显式的范围约束"
 
-#: ../../language/verification.md:431
+#: ../../language/verification.md:476
 msgid "machine-integer verification is planned, but is not the current default"
 msgstr "机器整数验证已经在计划中，但目前还不是默认模型"
 
-#: ../../language/verification.md:433
+#: ../../language/verification.md:478
 msgid "Current Status"
 msgstr "当前状态"
 
-#: ../../language/verification.md:435
+#: ../../language/verification.md:480
 msgid ""
 "Formal verification in MoonBit is still experimental. The surface syntax,"
 " prover integration, and proof ergonomics are actively evolving, so it is"
@@ -1223,41 +1313,41 @@ msgstr ""
 "MoonBit "
 "中的形式化验证仍处于实验阶段。表面语法、证明器集成和证明易用性都还在快速演进，因此最好把它视为一种高级特性，主要面向那些确实能从强而可机检的保证中受益的包。"
 
-#: ../../language/verification.md:440
+#: ../../language/verification.md:485
 msgid "Preferred Verification Style"
 msgstr "推荐的验证风格"
 
-#: ../../language/verification.md:442
+#: ../../language/verification.md:487
 msgid ""
 "MoonBit's current verifier works best with a functional proof style and "
 "model-based specifications."
 msgstr "MoonBit 当前的验证器最适合函数式的证明风格，以及基于模型的规范。"
 
-#: ../../language/verification.md:445
+#: ../../language/verification.md:490
 msgid ""
 "Imperative features such as local mutation and in-place `FixedArray` "
 "updates are supported, but their verified use is more limited:"
 msgstr "诸如局部可变状态和原地 `FixedArray` 更新这样的命令式特性虽然受支持，但它们在验证中的使用限制更多："
 
-#: ../../language/verification.md:448
+#: ../../language/verification.md:493
 msgid "mutable state is expected to remain local"
 msgstr "可变状态应当保持为局部使用"
 
-#: ../../language/verification.md:449
+#: ../../language/verification.md:494
 msgid "escaping uses of `FixedArray` are currently not supported"
 msgstr "`FixedArray` 的逃逸式使用目前还不受支持"
 
-#: ../../language/verification.md:450
+#: ../../language/verification.md:495
 msgid ""
 "when both formulations are available, functional-style programs are "
 "preferred"
 msgstr "当两种写法都可行时，优先选择函数式风格的程序"
 
-#: ../../language/verification.md:452
+#: ../../language/verification.md:497
 msgid "Further Reading"
 msgstr "进一步阅读"
 
-#: ../../language/verification.md:454
+#: ../../language/verification.md:499
 msgid ""
 "For additional verified programs and reusable proof-oriented libraries, "
 "see the [`moonbit-community/verified`](https://github.com/moonbit-"

--- a/next/sources/verification/src/proof_shim.mbt
+++ b/next/sources/verification/src/proof_shim.mbt
@@ -1,0 +1,5 @@
+// start proof external 1
+///|
+#proof_external("set.Fset", "fset")
+pub type ProofSet[T]
+// end proof external 1

--- a/next/sources/verification/src/proof_shim.mbtp
+++ b/next/sources/verification/src/proof_shim.mbtp
@@ -1,0 +1,17 @@
+// start proof import 1
+#proof_import("set.Fset")
+fn proof_set_mem(x : Int, set : ProofSet[Int]) -> Bool = "mem"
+
+#proof_import("set.Fset")
+fn proof_set_empty() -> ProofSet[Int] = "empty"
+
+#proof_import("set.Fset")
+fn proof_set_add(x : Int, set : ProofSet[Int]) -> ProofSet[Int] = "add"
+
+lemma proof_set_add_contains(x : Int) where {
+  proof_ensure: proof_set_mem(
+    x,
+    proof_set_add(x, proof_set_empty()),
+  ),
+} {}
+// end proof import 1


### PR DESCRIPTION
## Summary

- add dedicated reference pages for `#proof_pure`, `#proof_external`, and `#proof_import`
- explain how proof-only Why3 type and symbol mappings differ from runtime code and FFI
- add a finite-set import example with a real lemma, plus synchronized Chinese and Japanese catalogs

## Why

These compiler-recognized attributes were missing from the attribute reference, including the per-attribute pages consumed by attribute explanation tooling. The formal-verification guide also did not explain who `#proof_import` imports from or where the external mapping enters the trusted boundary.

## Correctness and scope

The example maps an opaque MoonBit type and three proof-only stubs to Why3's finite-set theory, then proves membership after insertion. The change is limited to the attribute index, the formal-verification guide, its runnable example, and the corresponding locale catalogs.