### PR TITLE
fix(docs): make generated Markdown links absolute

### DIFF
--- a/next/conf.py
+++ b/next/conf.py
@@ -49,6 +49,13 @@ smartquotes_excludes = {
   'builders': ['man', 'text', 'markdown', 'latex'],
 }
 
+# Keep generated Markdown links usable when pages are consumed out of tree.
+markdown_http_base = {
+    'zh_CN': 'https://docs.moonbitlang.cn',
+    'ja': 'https://docs.moonbitlang.com/ja/latest',
+}.get(globals().get('language'), 'https://docs.moonbitlang.com/en/latest')
+markdown_uri_doc_suffix = '.html'
+
 # Avoid guess-highlighting output blocks and other snippets without a language.
 highlight_language = 'none'
 


### PR DESCRIPTION
## Why

Generated Markdown currently contains relative internal links. They work only when consumers preserve the original directory layout; tools that fetch an individual page or consume flattened Markdown do not know the link base.

## What changed

- Configure the Markdown builder to emit canonical documentation URLs for English, Chinese, and Japanese output.
- Use `.html` targets so generated links point to the published documentation site.

## Why this is correct

The Markdown builder resolves internal references through its HTTP base and document suffix settings. The change is confined to the Sphinx configuration, leaves source documents untouched, and does not alter HTML builder link generation.