### PR TITLE
ci: install scrut from GitHub releases

### DIFF
--- a/.github/workflows/next-check.yml
+++ b/.github/workflows/next-check.yml
@@ -6,6 +6,7 @@ on:
       - main
   pull_request:
     paths:
+      - .github/workflows/next-check.yml
       - next/**
   schedule:
     - cron: "0 10 * * 2"
@@ -40,11 +41,37 @@ jobs:
         run: |
           python next/check_error_docs.py all
 
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-
       - name: Install scrut
-        run: cargo install --locked scrut
+        shell: bash
+        run: |
+          case "$RUNNER_OS-$RUNNER_ARCH" in
+            Linux-X64)
+              scrut_archive=scrut-v0.4.3-linux-x86_64.tar.gz
+              scrut_dir=scrut-linux-x86_64
+              ;;
+            macOS-ARM64)
+              scrut_archive=scrut-v0.4.3-macos-aarch64.tar.gz
+              scrut_dir=scrut-macos-aarch64
+              ;;
+            Windows-X64)
+              scrut_archive=scrut-v0.4.3-windows-x86_64.zip
+              scrut_dir=scrut-windows-x86_64
+              ;;
+            *)
+              echo "Unsupported runner: $RUNNER_OS-$RUNNER_ARCH" >&2
+              exit 1
+              ;;
+          esac
+          mkdir -p "$RUNNER_TEMP/scrut"
+          curl --fail --location --retry 3 \
+            --output "$RUNNER_TEMP/scrut/$scrut_archive" \
+            "https://github.com/facebookincubator/scrut/releases/download/v0.4.3/$scrut_archive"
+          if [[ "$RUNNER_OS" == Windows ]]; then
+            unzip -q "$RUNNER_TEMP/scrut/$scrut_archive" -d "$RUNNER_TEMP/scrut"
+          else
+            tar -xzf "$RUNNER_TEMP/scrut/$scrut_archive" -C "$RUNNER_TEMP/scrut"
+          fi
+          echo "$RUNNER_TEMP/scrut/$scrut_dir" >> "$GITHUB_PATH"
 
       - name: Workspace command transcript
         shell: bash


### PR DESCRIPTION
## Why

The document-check workflow compiled Scrut from source independently in every operating-system job, adding substantial time to pull request CI.

## What changed

- Download the pinned Scrut 0.4.3 binary from its official GitHub Release for each runner platform.
- Extract the archive and add the contained executable to PATH.
- Include the workflow file in its pull request path filter so workflow-only changes exercise the check before merge.

The selected assets match the architecture of the existing Linux, macOS, and Windows runners. This removes Rust setup and compilation without changing the transcript commands or cross-platform coverage, keeping the change limited to Scrut installation.